### PR TITLE
Bugfix: Nested capture scopes

### DIFF
--- a/src/Token.re
+++ b/src/Token.re
@@ -76,11 +76,37 @@ let ofMatch =
         None
       }
 
+      /*
+      If the rule is a 'push stack', the outer rule has already been applied
+      because the scope stack has been updated.
+      If there rule is not a 'push stack', then we need to apply the rule here
+      locally, for patterns like this:
+      
+		{
+			"match": "world(!?)",
+			"captures": {
+				"1": {
+					"name": "emphasis.hello"
+				}
+			},
+			"name": "suffix.hello"
+		}
+
+        For a string like "world!", we'd expect two tokens:
+        - "hello" - ["suffix.hello"]
+        - "!" - ["emphasis.hello", "suffix.hello"]
+      */
+      
+      let outerScope = switch((rule.pushStack, rule.popStack)) {
+      | (None, false) => Some(rule.name)
+      | _ => None;
+      }
+
       let captureToken = create(
         ~position=match.startPos,
         ~length=match.length,
         ~scope,
-        ~outerScope=Some(rule.name),
+        ~outerScope,
         ~scopeStack,
         (),
       );

--- a/src/Token.re
+++ b/src/Token.re
@@ -11,13 +11,21 @@ type t = {
 };
 
 let create =
-    (~position, ~length, ~scope: string, ~outerScope=None,  ~scopeStack: ScopeStack.t, ()) => {
+    (
+      ~position,
+      ~length,
+      ~scope: string,
+      ~outerScope=None,
+      ~scopeStack: ScopeStack.t,
+      (),
+    ) => {
   let scopeNames = ScopeStack.getScopes(scopeStack);
 
-  let scopes = switch(outerScope) {
-  | None => [scope, ...scopeNames]
-  | Some(v) => [scope, v, ...scopeNames]
-  }
+  let scopes =
+    switch (outerScope) {
+    | None => [scope, ...scopeNames]
+    | Some(v) => [scope, v, ...scopeNames]
+    };
 
   let ret: t = {length, position, scopes};
   ret;
@@ -56,74 +64,81 @@ let ofMatch =
     ];
   | v =>
     let initialMatch = matches[0];
-    let (_, tokens) = List.fold_left((prev, curr) => {
-      let (pos, tokens) = prev;
+    let (_, tokens) =
+      List.fold_left(
+        (prev, curr) => {
+          let (pos, tokens) = prev;
 
-      let (idx, scope) = curr;
-      let match = matches[idx];
+          let (idx, scope) = curr;
+          let match = matches[idx];
 
-      // Was there any space between the last position and the capture?
-      // If so - create a token to fill in that space
-      let firstToken = if (match.startPos > pos) {
-        Some(create(
-        ~position=pos,
-        ~length=match.startPos - pos,
-        ~scope=rule.name,
-        ~scopeStack,
-        ()
-        ))
-      } else {
-        None
-      }
+          // Was there any space between the last position and the capture?
+          // If so - create a token to fill in that space
+          let firstToken =
+            if (match.startPos > pos) {
+              Some(
+                create(
+                  ~position=pos,
+                  ~length=match.startPos - pos,
+                  ~scope=rule.name,
+                  ~scopeStack,
+                  (),
+                ),
+              );
+            } else {
+              None;
+            };
 
-      /*
-      If the rule is a 'push stack', the outer rule has already been applied
-      because the scope stack has been updated.
-      If there rule is not a 'push stack', then we need to apply the rule here
-      locally, for patterns like this:
-      
-		{
-			"match": "world(!?)",
-			"captures": {
-				"1": {
-					"name": "emphasis.hello"
-				}
-			},
-			"name": "suffix.hello"
-		}
+          /*
+               If the rule is a 'push stack', the outer rule has already been applied
+               because the scope stack has been updated.
+               If there rule is not a 'push stack', then we need to apply the rule here
+               locally, for patterns like this:
 
-        For a string like "world!", we'd expect two tokens:
-        - "hello" - ["suffix.hello"]
-        - "!" - ["emphasis.hello", "suffix.hello"]
-      */
-      
-      let outerScope = switch((rule.pushStack, rule.popStack)) {
-      | (None, false) => Some(rule.name)
-      | _ => None;
-      }
+           {
+           	"match": "world(!?)",
+           	"captures": {
+           		"1": {
+           			"name": "emphasis.hello"
+           		}
+           	},
+           	"name": "suffix.hello"
+           }
 
-      let captureToken = create(
-        ~position=match.startPos,
-        ~length=match.length,
-        ~scope,
-        ~outerScope,
-        ~scopeStack,
-        (),
+                 For a string like "world!", we'd expect two tokens:
+                 - "hello" - ["suffix.hello"]
+                 - "!" - ["emphasis.hello", "suffix.hello"]
+               */
+
+          let outerScope =
+            switch (rule.pushStack, rule.popStack) {
+            | (None, false) => Some(rule.name)
+            | _ => None
+            };
+
+          let captureToken =
+            create(
+              ~position=match.startPos,
+              ~length=match.length,
+              ~scope,
+              ~outerScope,
+              ~scopeStack,
+              (),
+            );
+
+          let tokens =
+            switch (firstToken) {
+            | Some(v) => [captureToken, v, ...tokens]
+            | None => [captureToken, ...tokens]
+            };
+
+          let newPos = match.startPos + match.length;
+          (newPos, tokens);
+        },
+        (initialMatch.startPos, []),
+        v,
       );
 
-      let tokens = switch (firstToken) {
-      | Some(v) => [captureToken, v, ...tokens]
-      | None => [captureToken, ...tokens];
-      };
-
-      let newPos = match.startPos + match.length;
-      (newPos, tokens);
-      
-
-    }, (initialMatch.startPos, []), v);
-
-    tokens
-    |> List.filter(t => t.length > 0)
-    |> List.rev;
+    tokens |> List.filter(t => t.length > 0) |> List.rev;
   };
 };

--- a/test/GrammarCaptureTests.re
+++ b/test/GrammarCaptureTests.re
@@ -3,9 +3,7 @@
 
  Tests specific to 'capture' behavior
 */
-
 open TestFramework;
-
 
 open Oniguruma;
 module Grammar = Textmate.Grammar;
@@ -31,40 +29,34 @@ describe("GrammarCaptureTests", ({test, _}) => {
         Match({
           matchRegex: createRegex("world(!?)"),
           matchName: "suffix.hello",
-          captures: [
-          (1, "emphasis.hello")
-          ],
-        })
+          captures: [(1, "emphasis.hello")],
+        }),
       ],
       ~repository=[],
       (),
     );
 
-      test("match with both name + capture gets both scopes applied", ({expect, _}) => {
-        let (tokens, _) = Grammar.tokenize(~grammar, "world!");
-        
-        expect.int(List.length(tokens)).toBe(2);
+  test(
+    "match with both name + capture gets both scopes applied", ({expect, _}) => {
+    let (tokens, _) = Grammar.tokenize(~grammar, "world!");
 
-        let firstToken = List.hd(tokens);
-        expect.bool(
-          firstToken.scopes
-          == ["suffix.hello", "source.hello"],
-        ).
-          toBe(
-          true,
-        );
-        expect.int(firstToken.position).toBe(0);
-        expect.int(firstToken.length).toBe(5);
+    expect.int(List.length(tokens)).toBe(2);
 
-        let secondToken = List.nth(tokens, 1);
-        expect.bool(
-          secondToken.scopes
-          == ["emphasis.hello", "suffix.hello", "source.hello"],
-        ).
-          toBe(
-          true,
-        );
-        expect.int(secondToken.position).toBe(5);
-        expect.int(secondToken.length).toBe(1);
-      });
-    });
+    let firstToken = List.hd(tokens);
+    expect.bool(firstToken.scopes == ["suffix.hello", "source.hello"]).toBe(
+      true,
+    );
+    expect.int(firstToken.position).toBe(0);
+    expect.int(firstToken.length).toBe(5);
+
+    let secondToken = List.nth(tokens, 1);
+    expect.bool(
+      secondToken.scopes == ["emphasis.hello", "suffix.hello", "source.hello"],
+    ).
+      toBe(
+      true,
+    );
+    expect.int(secondToken.position).toBe(5);
+    expect.int(secondToken.length).toBe(1);
+  });
+});

--- a/test/GrammarCaptureTests.re
+++ b/test/GrammarCaptureTests.re
@@ -1,0 +1,70 @@
+/**
+ GrammarCaptureTests.re
+
+ Tests specific to 'capture' behavior
+*/
+
+open TestFramework;
+
+
+open Oniguruma;
+module Grammar = Textmate.Grammar;
+
+let createRegex = str => {
+  switch (OnigRegExp.create(str)) {
+  | Ok(v) => v
+  | Error(msg) =>
+    failwith("Unable to parse regex: " ++ str ++ " message: " ++ msg)
+  };
+};
+
+describe("GrammarCaptureTests", ({test, _}) => {
+  let grammar =
+    Grammar.create(
+      ~scopeName="source.hello",
+      ~patterns=[
+        Match({
+          matchRegex: createRegex("hello"),
+          matchName: "prefix.hello",
+          captures: [],
+        }),
+        Match({
+          matchRegex: createRegex("world(!?)"),
+          matchName: "suffix.hello",
+          captures: [
+          (1, "emphasis.hello")
+          ],
+        })
+      ],
+      ~repository=[],
+      (),
+    );
+
+      test("match with both name + capture gets both scopes applied", ({expect, _}) => {
+        let (tokens, _) = Grammar.tokenize(~grammar, "world!");
+        
+        expect.int(List.length(tokens)).toBe(2);
+
+        let firstToken = List.hd(tokens);
+        expect.bool(
+          firstToken.scopes
+          == ["suffix.hello", "source.hello"],
+        ).
+          toBe(
+          true,
+        );
+        expect.int(firstToken.position).toBe(0);
+        expect.int(firstToken.length).toBe(5);
+
+        let secondToken = List.nth(tokens, 1);
+        expect.bool(
+          secondToken.scopes
+          == ["emphasis.hello", "suffix.hello", "source.hello"],
+        ).
+          toBe(
+          true,
+        );
+        expect.int(secondToken.position).toBe(5);
+        expect.int(secondToken.length).toBe(1);
+      });
+    });

--- a/test/GrammarTests.re
+++ b/test/GrammarTests.re
@@ -292,7 +292,10 @@ describe("Grammar", ({describe, _}) => {
         Grammar.tokenize(~grammar, "@selector(windowWillClose:)");
       expect.int(List.length(tokens)).toBe(3);
       let firstToken = List.hd(tokens);
-      expect.bool(firstToken.scopes == ["storage.type.objc", "capture-group", "source.abc"]).
+      expect.bool(
+        firstToken.scopes
+        == ["storage.type.objc", "capture-group", "source.abc"],
+      ).
         toBe(
         true,
       );
@@ -300,7 +303,10 @@ describe("Grammar", ({describe, _}) => {
       expect.int(firstToken.length).toBe(10);
 
       let thirdToken = List.nth(tokens, 2);
-      expect.bool(thirdToken.scopes == ["storage.type.objc", "capture-group", "source.abc"]).
+      expect.bool(
+        thirdToken.scopes
+        == ["storage.type.objc", "capture-group", "source.abc"],
+      ).
         toBe(
         true,
       );

--- a/test/GrammarTests.re
+++ b/test/GrammarTests.re
@@ -80,7 +80,7 @@ describe("Grammar", ({describe, _}) => {
           [
             Match({
               matchRegex: createRegex("(@selector\\()(.*?)(\\))"),
-              matchName: "",
+              matchName: "capture-group",
               captures: [
                 (1, "storage.type.objc"),
                 (3, "storage.type.objc"),
@@ -290,22 +290,22 @@ describe("Grammar", ({describe, _}) => {
     test("capture groups", ({expect, _}) => {
       let (tokens, _) =
         Grammar.tokenize(~grammar, "@selector(windowWillClose:)");
-      expect.int(List.length(tokens)).toBe(2);
+      expect.int(List.length(tokens)).toBe(3);
       let firstToken = List.hd(tokens);
-      expect.bool(firstToken.scopes == ["storage.type.objc", "source.abc"]).
+      expect.bool(firstToken.scopes == ["storage.type.objc", "capture-group", "source.abc"]).
         toBe(
         true,
       );
       expect.int(firstToken.position).toBe(0);
       expect.int(firstToken.length).toBe(10);
 
-      let secondToken = List.nth(tokens, 1);
-      expect.bool(secondToken.scopes == ["storage.type.objc", "source.abc"]).
+      let thirdToken = List.nth(tokens, 2);
+      expect.bool(thirdToken.scopes == ["storage.type.objc", "capture-group", "source.abc"]).
         toBe(
         true,
       );
-      expect.int(secondToken.position).toBe(26);
-      expect.int(secondToken.length).toBe(1);
+      expect.int(thirdToken.position).toBe(26);
+      expect.int(thirdToken.length).toBe(1);
     });
     test("simple letter token", ({expect, _}) => {
       let (tokens, _) = Grammar.tokenize(~grammar, "a");
@@ -353,26 +353,6 @@ describe("Grammar", ({describe, _}) => {
       );
       expect.int(thirdToken.position).toBe(6);
       expect.int(thirdToken.length).toBe(1);
-    });
-    test("capture groups", ({expect, _}) => {
-      let (tokens, _) =
-        Grammar.tokenize(~grammar, "@selector(windowWillClose:)");
-      expect.int(List.length(tokens)).toBe(2);
-      let firstToken = List.hd(tokens);
-      expect.bool(firstToken.scopes == ["storage.type.objc", "source.abc"]).
-        toBe(
-        true,
-      );
-      expect.int(firstToken.position).toBe(0);
-      expect.int(firstToken.length).toBe(10);
-
-      let secondToken = List.nth(tokens, 1);
-      expect.bool(secondToken.scopes == ["storage.type.objc", "source.abc"]).
-        toBe(
-        true,
-      );
-      expect.int(secondToken.position).toBe(26);
-      expect.int(secondToken.length).toBe(1);
     });
   });
 });


### PR DESCRIPTION
In the case of a match rule like this:
```
	   {
           	"match": "world(!?)",
           	"captures": {
           		"1": {
           			"name": "emphasis.hello"
           		}
           	},
           	"name": "suffix.hello"
           }
```

For a string like "world!", we'd expect two tokens:
 - "hello" - ["suffix.hello"]
 - "!" - ["emphasis.hello", "suffix.hello"]

However, the current logic was _only_ processing the capture-group tokens, so only the `"!"` showed up as a token.

This fixes it by processing everything across the match properly - not just the capture groups.