### PR TITLE
Bugfix: Out-of-order token

### DIFF
--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -234,7 +234,17 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     };
   };
 
-  let retTokens = tokens^ |> List.rev |> List.flatten;
+  // There might be some leftover whitespace or tokens
+  // that weren't processed through our loop iteration.
+  let tokens = if(lastTokenPosition^ < len) {
+    [[Token.create(~position=lastTokenPosition^, 
+            ~length=len-lastTokenPosition^,
+            ~scopeStack=scopeStack^, ())], ...tokens^]
+  } else {
+    tokens^
+  }
+
+  let retTokens = tokens |> List.rev |> List.flatten;
 
   let scopeStack = scopeStack^;
 

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -236,13 +236,22 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
 
   // There might be some leftover whitespace or tokens
   // that weren't processed through our loop iteration.
-  let tokens = if(lastTokenPosition^ < len) {
-    [[Token.create(~position=lastTokenPosition^, 
-            ~length=len-lastTokenPosition^,
-            ~scopeStack=scopeStack^, ())], ...tokens^]
-  } else {
-    tokens^
-  }
+  let tokens =
+    if (lastTokenPosition^ < len) {
+      [
+        [
+          Token.create(
+            ~position=lastTokenPosition^,
+            ~length=len - lastTokenPosition^,
+            ~scopeStack=scopeStack^,
+            (),
+          ),
+        ],
+        ...tokens^,
+      ];
+    } else {
+      tokens^;
+    };
 
   let retTokens = tokens |> List.rev |> List.flatten;
 

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -62,7 +62,7 @@ module Json = {
       };
 
       switch (json) {
-      | `Assoc(list) => List.fold_left(fold, [], list)
+      | `Assoc(list) => List.fold_left(fold, [], list) |> List.rev;
       | _ => []
       };
     };

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -62,7 +62,7 @@ module Json = {
       };
 
       switch (json) {
-      | `Assoc(list) => List.fold_left(fold, [], list) |> List.rev;
+      | `Assoc(list) => List.fold_left(fold, [], list) |> List.rev
       | _ => []
       };
     };

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -97,5 +97,67 @@
 			"fixtures/coffee-script.json"
 		],
 		"desc": "TEST #5"
+	},
+	{
+		"grammarScopeName": "source.coffee",
+		"lines": [
+			{
+				"line": " return new foo.bar.Baz ",
+				"tokens": [
+					{
+						"value": " ",
+						"scopes": [
+							"source.coffee"
+						]
+					},
+					{
+						"value": "return",
+						"scopes": [
+							"source.coffee",
+							"keyword.control.coffee"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.coffee"
+						]
+					},
+					{
+						"value": "new",
+						"scopes": [
+							"source.coffee",
+							"meta.class.instance.constructor",
+							"keyword.operator.new.coffee"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.coffee",
+							"meta.class.instance.constructor"
+						]
+					},
+					{
+						"value": "foo.bar.Baz",
+						"scopes": [
+							"source.coffee",
+							"meta.class.instance.constructor",
+							"entity.name.type.instance.coffee"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.coffee"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/coffee-script.json"
+		],
+		"desc": "TEST #7"
 	}
 ]

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -60,5 +60,42 @@
 			"fixtures/coffee-script.json"
 		],
 		"desc": "TEST #4"
+	},
+	{
+		"grammarScopeName": "source.coffee",
+		"lines": [
+			{
+				"line": "new foo.bar.Baz",
+				"tokens": [
+					{
+						"value": "new",
+						"scopes": [
+							"source.coffee",
+							"meta.class.instance.constructor",
+							"keyword.operator.new.coffee"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.coffee",
+							"meta.class.instance.constructor"
+						]
+					},
+					{
+						"value": "foo.bar.Baz",
+						"scopes": [
+							"source.coffee",
+							"meta.class.instance.constructor",
+							"entity.name.type.instance.coffee"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/coffee-script.json"
+		],
+		"desc": "TEST #5"
 	}
 ]

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -159,5 +159,42 @@
 			"fixtures/coffee-script.json"
 		],
 		"desc": "TEST #7"
+	},
+	{
+		"grammarScopeName": "source.coffee",
+		"lines": [
+			{
+				"line": "class Quicksort",
+				"tokens": [
+					{
+						"value": "class",
+						"scopes": [
+							"source.coffee",
+							"meta.class.coffee",
+							"storage.type.class.coffee"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.coffee",
+							"meta.class.coffee"
+						]
+					},
+					{
+						"value": "Quicksort",
+						"scopes": [
+							"source.coffee",
+							"meta.class.coffee",
+							"entity.name.type.class.coffee"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/coffee-script.json"
+		],
+		"desc": "TEST #8"
 	}
 ]


### PR DESCRIPTION
This fixes the next test failure - there was a bug due to the order reversal of capture groups during parsing. We assume that the capture groups are traversed in order in order to properly tokenize spaces between them, but this wasn't the case when the order was reversed.