### PR TITLE
Bugfix: Grammar Parsing

### DIFF
--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -229,7 +229,8 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
           scopeStack := ScopeStack.pop(scopeStack^);
         };
 
-        idx := matches[0].endPos;
+        let prevIndex = idx^;
+        idx := max(matches[0].endPos, prevIndex + 1);
         lastTokenPosition := matches[0].endPos;
       } else {
         incr(idx);

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -75,7 +75,6 @@ module Json = {
 
   let match_of_yojson: Yojson.Safe.t => result(t, string) =
     json => {
-      prerr_endline("match_of_yojson");
       open Yojson.Safe.Util;
       let%bind regex = regex_of_yojson(member("match", json));
 
@@ -117,7 +116,6 @@ module Json = {
   and matchRange_of_yojson: Yojson.Safe.t => result(t, string) =
     json => {
       open Yojson.Safe.Util;
-      prerr_endline("matchRange_of_yojson");
       let%bind beginRegex = regex_of_yojson(member("begin", json));
       let%bind endRegex = regex_of_yojson(member("end", json));
 

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -4,14 +4,17 @@
 
 type t = {
   regex: RegExp.t,
-  name: string,
+  name: option(string),
   captures: list(Pattern.Capture.t),
   popStack: bool,
   pushStack: option(Pattern.matchRange),
 };
 
 let show = (v: t) => {
-  "Rule " ++ v.name;
+  switch (v.name) {
+  | Some(rule) => "Rule " ++ rule
+  | None => "Rule (anonymous)"
+  };
 };
 
 let ofMatch = (match: Pattern.match_) => {

--- a/src/ScopeStack.re
+++ b/src/ScopeStack.re
@@ -30,7 +30,12 @@ let activePatterns = (v: t) => {
 
 let getScopes = (v: t) => {
   List.fold_left(
-    (prev, curr: Pattern.matchRange) => {[curr.matchScopeName, ...prev]},
+    (prev, curr: Pattern.matchRange) => {
+      switch (curr.matchScopeName) {
+      | None => prev
+      | Some(v) => [v, ...prev]
+      }
+    },
     [v.initialScopeName],
     v.scopes,
   );

--- a/src/Token.re
+++ b/src/Token.re
@@ -59,7 +59,7 @@ let ofMatch =
       create(
         ~position=match.startPos,
         ~length=match.length,
-        ~scope=Some(rule.name),
+        ~scope=rule.name,
         ~scopeStack,
         (),
       ),
@@ -82,7 +82,7 @@ let ofMatch =
                 create(
                   ~position=pos,
                   ~length=match.startPos - pos,
-                  ~scope=Some(rule.name),
+                  ~scope=rule.name,
                   ~scopeStack,
                   (),
                 ),
@@ -114,7 +114,7 @@ let ofMatch =
 
           let outerScope =
             switch (rule.pushStack, rule.popStack) {
-            | (None, false) => Some(rule.name)
+            | (None, false) => rule.name
             | _ => None
             };
 

--- a/test/GrammarCaptureTests.re
+++ b/test/GrammarCaptureTests.re
@@ -24,12 +24,12 @@ describe("GrammarCaptureTests", ({test, _}) => {
       ~patterns=[
         Match({
           matchRegex: createRegex("hello"),
-          matchName: "prefix.hello",
+          matchName: Some("prefix.hello"),
           captures: [],
         }),
         Match({
           matchRegex: createRegex("world(!?)"),
-          matchName: "suffix.hello",
+          matchName: Some("suffix.hello"),
           captures: [(1, "emphasis.hello")],
         }),
         MatchRange({
@@ -37,7 +37,7 @@ describe("GrammarCaptureTests", ({test, _}) => {
           endRegex: createRegex("</\\1>"),
           beginCaptures: [(0, "html.tag.open")],
           endCaptures: [(0, "html.tag.close")],
-          matchScopeName: "html.tag.contents",
+          matchScopeName: Some("html.tag.contents"),
           patterns: [],
         }),
       ],

--- a/test/GrammarTests.re
+++ b/test/GrammarTests.re
@@ -59,7 +59,7 @@ describe("Grammar", ({describe, _}) => {
           [
             Match({
               matchRegex: createRegex("a|b|c"),
-              matchName: "keyword.letter",
+              matchName: Some("keyword.letter"),
               captures: [],
             }),
           ],
@@ -69,7 +69,7 @@ describe("Grammar", ({describe, _}) => {
           [
             Match({
               matchRegex: createRegex("def"),
-              matchName: "keyword.word",
+              matchName: Some("keyword.word"),
               captures: [],
             }),
           ],
@@ -79,7 +79,7 @@ describe("Grammar", ({describe, _}) => {
           [
             Match({
               matchRegex: createRegex("(@selector\\()(.*?)(\\))"),
-              matchName: "capture-group",
+              matchName: Some("capture-group"),
               captures: [
                 (1, "storage.type.objc"),
                 (3, "storage.type.objc"),
@@ -95,7 +95,7 @@ describe("Grammar", ({describe, _}) => {
               endRegex: createRegex("\\)"),
               beginCaptures: [(0, "punctuation.paren.open")],
               endCaptures: [(0, "punctuation.paren.close")],
-              matchScopeName: "expression.group",
+              matchScopeName: Some("expression.group"),
               patterns: [Include("#expression")],
             }),
           ],

--- a/test/PatternTests.re
+++ b/test/PatternTests.re
@@ -16,7 +16,7 @@ describe("Pattern", ({describe, _}) => {
 
       switch (match1) {
       | Ok(Match(v)) =>
-        expect.string(v.matchName).toEqual("match1");
+        expect.bool(v.matchName == Some("match1")).toBe(true);
         expect.int(List.length(v.captures)).toBe(0);
       | _ => failwith("Parse failed for match")
       };
@@ -28,7 +28,7 @@ describe("Pattern", ({describe, _}) => {
 
       switch (matchWithCapture) {
       | Ok(Match(v)) =>
-        expect.string(v.matchName).toEqual("match2");
+        expect.bool(v.matchName == Some("match2")).toBe(true);
         expect.int(List.length(v.captures)).toBe(1);
       | _ => failwith("Parse failed for match")
       };
@@ -52,7 +52,7 @@ describe("Pattern", ({describe, _}) => {
 
       switch (matchRange1) {
       | Ok(MatchRange(v)) =>
-        expect.string(v.matchScopeName).toEqual("array-json");
+        expect.bool(v.matchScopeName == Some("array-json")).toBe(true);
         expect.int(List.length(v.beginCaptures)).toBe(1);
         expect.int(List.length(v.endCaptures)).toBe(1);
       | _ => failwith("Parse failed for match")

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -115,7 +115,17 @@
 			}
 		],
 		"grammars": [
-			"fixtures/coffee-script.json"
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json",
+			"fixtures/hello.json"
 		],
 		"desc": "TEST #5"
 	},
@@ -177,7 +187,17 @@
 			}
 		],
 		"grammars": [
-			"fixtures/coffee-script.json"
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json",
+			"fixtures/hello.json"
 		],
 		"desc": "TEST #7"
 	},
@@ -214,7 +234,17 @@
 			}
 		],
 		"grammars": [
-			"fixtures/coffee-script.json"
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json",
+			"fixtures/hello.json"
 		],
 		"desc": "TEST #8"
 	}

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -37,6 +37,17 @@
 			}
 		],
 		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json",
+			"fixtures/hello.json"
 		],
 		"desc": "TEST #3"
 	},
@@ -57,7 +68,17 @@
 			}
 		],
 		"grammars": [
-			"fixtures/coffee-script.json"
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json",
+			"fixtures/hello.json"
 		],
 		"desc": "TEST #4"
 	},


### PR DESCRIPTION
This fixes some remaining issues around parsing the corpus of grammars - in particular, we weren't handling cases where `name`/`contentName` fields are missing.

With this change, the full corpus of test grammars now can be loaded without an exception (there are still bugs to fix around tokenization, though).