### PR TITLE
Bugfix: Fix test #6

### DIFF
--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -218,12 +218,16 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
             )
         };
 
+        // Only add token if there was actually a match!
+        if (matches[0].endPos > matches[0].startPos) {
         tokens :=
           [
             Token.ofMatch(~matches, ~rule, ~scopeStack=scopeStack^, ()),
             prevToken,
             ...tokens^,
           ];
+        lastTokenPosition := matches[0].endPos;
+        }
 
         if (rule.popStack) {
           scopeStack := ScopeStack.pop(scopeStack^);
@@ -231,7 +235,6 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
 
         let prevIndex = idx^;
         idx := max(matches[0].endPos, prevIndex + 1);
-        lastTokenPosition := matches[0].endPos;
       } else {
         incr(idx);
       };

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -220,14 +220,14 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
 
         // Only add token if there was actually a match!
         if (matches[0].endPos > matches[0].startPos) {
-        tokens :=
-          [
-            Token.ofMatch(~matches, ~rule, ~scopeStack=scopeStack^, ()),
-            prevToken,
-            ...tokens^,
-          ];
-        lastTokenPosition := matches[0].endPos;
-        }
+          tokens :=
+            [
+              Token.ofMatch(~matches, ~rule, ~scopeStack=scopeStack^, ()),
+              prevToken,
+              ...tokens^,
+            ];
+          lastTokenPosition := matches[0].endPos;
+        };
 
         if (rule.popStack) {
           scopeStack := ScopeStack.pop(scopeStack^);

--- a/src/Token.re
+++ b/src/Token.re
@@ -74,11 +74,7 @@ let ofMatch =
           let (idx, scope) = curr;
           let match = matches[idx];
 
-          prerr_endline ("MATCH - |" ++ match.match ++ "|" ++ string_of_int(match.startPos) ++ "-" ++ string_of_int(match.endPos));
-          if (match.endPos - match.startPos == 0) {
-            prev
-          } else {
-
+          // prerr_endline ("MATCH - |" ++ match.match ++ "|" ++ string_of_int(match.startPos) ++ "-" ++ string_of_int(match.endPos));
 
           // Was there any space between the last position and the capture?
           // If so - create a token to fill in that space
@@ -142,7 +138,6 @@ let ofMatch =
 
           let newPos = match.startPos + match.length;
           (newPos, tokens);
-          }
         },
         (initialMatch.startPos, []),
         v,

--- a/src/Token.re
+++ b/src/Token.re
@@ -74,6 +74,12 @@ let ofMatch =
           let (idx, scope) = curr;
           let match = matches[idx];
 
+          prerr_endline ("MATCH - |" ++ match.match ++ "|" ++ string_of_int(match.startPos) ++ "-" ++ string_of_int(match.endPos));
+          if (match.endPos - match.startPos == 0) {
+            prev
+          } else {
+
+
           // Was there any space between the last position and the capture?
           // If so - create a token to fill in that space
           let firstToken =
@@ -136,6 +142,7 @@ let ofMatch =
 
           let newPos = match.startPos + match.length;
           (newPos, tokens);
+          }
         },
         (initialMatch.startPos, []),
         v,

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -247,5 +247,65 @@
 			"fixtures/hello.json"
 		],
 		"desc": "TEST #8"
+	},
+	{
+		"grammarScopeName": "source.coffee",
+		"lines": [
+			{
+				"line": "7777777",
+				"tokens": [
+					{
+						"value": "7777777",
+						"scopes": [
+							"source.coffee",
+							"constant.numeric.coffee"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json"
+		],
+		"desc": "TEST #10"
+	},
+	{
+		"grammarScopeName": "text.plain",
+		"lines": [
+			{
+				"line": "abc def",
+				"tokens": [
+					{
+						"value": "abc def",
+						"scopes": [
+							"text.plain",
+							"meta.paragraph.text"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json"
+		],
+		"desc": "TEST #6"
 	}
 ]


### PR DESCRIPTION
__Issue:__ Some begin / end pairs would use lookahead to match positions, but not actually match a token. We were creating 0-length tokens in this case, which was not correct.

__Fix:__ Don't add 0-length tokens.