### PR TITLE
Bugfix: Get test #9 passing

### DIFF
--- a/src/Token.re
+++ b/src/Token.re
@@ -72,17 +72,17 @@ let ofMatch =
     ];
   | v =>
     let initialMatch = matches[0];
-    
+
     /*prerr_endline(
-      "INITIALMATCH - |"
-      ++ initialMatch.match
-      ++ "|"
-      ++ string_of_int(initialMatch.startPos)
-      ++ "-"
-      ++ string_of_int(initialMatch.endPos)
-      ++ " length: "
-      ++ string_of_int(initialMatch.length),
-    );*/
+        "INITIALMATCH - |"
+        ++ initialMatch.match
+        ++ "|"
+        ++ string_of_int(initialMatch.startPos)
+        ++ "-"
+        ++ string_of_int(initialMatch.endPos)
+        ++ " length: "
+        ++ string_of_int(initialMatch.length),
+      );*/
 
     /*If the rule is a 'push stack', the outer rule has already been applied
           because the scope stack has been updated.
@@ -120,15 +120,15 @@ let ofMatch =
         let (idx, scope) = cg;
         let match = matches[idx];
         /*prerr_endline(
-          " --MATCH - |"
-          ++ match.match
-          ++ "|"
-          ++ string_of_int(match.startPos)
-          ++ "-"
-          ++ string_of_int(match.endPos)
-          ++ " length: "
-          ++ string_of_int(match.length),
-        );*/
+            " --MATCH - |"
+            ++ match.match
+            ++ "|"
+            ++ string_of_int(match.startPos)
+            ++ "-"
+            ++ string_of_int(match.endPos)
+            ++ " length: "
+            ++ string_of_int(match.length),
+          );*/
 
         if (match.length > 0 && match.startPos < initialMatch.endPos) {
           let idx = ref(match.startPos - initialMatch.startPos);

--- a/src/Token.re
+++ b/src/Token.re
@@ -72,7 +72,8 @@ let ofMatch =
     ];
   | v =>
     let initialMatch = matches[0];
-    prerr_endline(
+    
+    /*prerr_endline(
       "INITIALMATCH - |"
       ++ initialMatch.match
       ++ "|"
@@ -81,7 +82,7 @@ let ofMatch =
       ++ string_of_int(initialMatch.endPos)
       ++ " length: "
       ++ string_of_int(initialMatch.length),
-    );
+    );*/
 
     /*If the rule is a 'push stack', the outer rule has already been applied
           because the scope stack has been updated.
@@ -118,7 +119,7 @@ let ofMatch =
       cg => {
         let (idx, scope) = cg;
         let match = matches[idx];
-        prerr_endline(
+        /*prerr_endline(
           " --MATCH - |"
           ++ match.match
           ++ "|"
@@ -127,7 +128,7 @@ let ofMatch =
           ++ string_of_int(match.endPos)
           ++ " length: "
           ++ string_of_int(match.length),
-        );
+        );*/
 
         if (match.length > 0 && match.startPos < initialMatch.endPos) {
           let idx = ref(match.startPos - initialMatch.startPos);

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -139,9 +139,13 @@ module FirstMateTest = {
         } else {
           failwith(
             "Strings do not match - actual: "
-            ++ "|" ++ actualTokenValue ++ "|"
+            ++ "|"
+            ++ actualTokenValue
+            ++ "|"
             ++ " expected: "
-            ++ "|" ++ expectedValue ++ "|",
+            ++ "|"
+            ++ expectedValue
+            ++ "|",
           );
         };
 

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -139,9 +139,9 @@ module FirstMateTest = {
         } else {
           failwith(
             "Strings do not match - actual: "
-            ++ actualTokenValue
+            ++ "|" ++ actualTokenValue ++ "|"
             ++ " expected: "
-            ++ expectedValue,
+            ++ "|" ++ expectedValue ++ "|",
           );
         };
 

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -307,5 +307,71 @@
 			"fixtures/python-regex.json"
 		],
 		"desc": "TEST #6"
+	},
+	{
+		"grammarScopeName": "source.coffee",
+		"lines": [
+			{
+				"line": "  destroy: ->",
+				"tokens": [
+					{
+						"value": "  ",
+						"scopes": [
+							"source.coffee"
+						]
+					},
+					{
+						"value": "destro",
+						"scopes": [
+							"source.coffee",
+							"meta.function.coffee",
+							"entity.name.function.coffee"
+						]
+					},
+					{
+						"value": "y",
+						"scopes": [
+							"source.coffee",
+							"meta.function.coffee",
+							"entity.name.function.coffee",
+							"entity.name.function.coffee"
+						]
+					},
+					{
+						"value": ":",
+						"scopes": [
+							"source.coffee",
+							"keyword.operator.coffee"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.coffee"
+						]
+					},
+					{
+						"value": "->",
+						"scopes": [
+							"source.coffee",
+							"storage.type.function.coffee"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json"
+		],
+		"desc": "TEST #9"
 	}
 ]


### PR DESCRIPTION
Test #9 exercises nested capture groups, which weren't handled correctly previously.

In the example, the `destroy` gets matched as:
- Group 1 - (2, 9) - `destroy` - `entity.name.function.coffee`
- Group 2 - (8, 9) - `y` - `entity.name.function.coffee`

This means the token from `8, 9` should have two `entity.name.function.coffee` scopes - but we didn't handle the case where we had overlapping matches.