### PR TITLE
Bugfix: Fix test cases #11 and #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ _esy/
 
 .merlin
 *.install
+camlppx.lastfail

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -179,6 +179,8 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     let currentScopeStack = scopeStack^;
     let patterns = ScopeStack.activePatterns(currentScopeStack);
 
+    prerr_endline ("Index: " ++ string_of_int(i) ++ " - scopes: " ++ ScopeStack.show(currentScopeStack));
+
     let rules =
       Rule.ofPatterns(
         ~getScope=v => getScope(v, grammar),

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -179,11 +179,11 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     let patterns = ScopeStack.activePatterns(currentScopeStack);
 
     /*prerr_endline(
-      "Index: "
-      ++ string_of_int(i)
-      ++ " - scopes: "
-      ++ ScopeStack.show(currentScopeStack),
-    );*/
+        "Index: "
+        ++ string_of_int(i)
+        ++ " - scopes: "
+        ++ ScopeStack.show(currentScopeStack),
+      );*/
 
     let rules =
       Rule.ofPatterns(

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -178,12 +178,12 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     let currentScopeStack = scopeStack^;
     let patterns = ScopeStack.activePatterns(currentScopeStack);
 
-    prerr_endline(
+    /*prerr_endline(
       "Index: "
       ++ string_of_int(i)
       ++ " - scopes: "
       ++ ScopeStack.show(currentScopeStack),
-    );
+    );*/
 
     let rules =
       Rule.ofPatterns(

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -9,13 +9,12 @@ type t = {
   repository: StringMap.t(list(Pattern.t)),
 };
 
-let getScope = (scope: string, v: t) => {
+let getScope = (scope: string, v: t) =>
   if (scope == "$self") {
-    Some(v.patterns)
+    Some(v.patterns);
   } else {
     StringMap.find_opt(scope, v.repository);
-  }
-};
+  };
 
 let getScopeName = (v: t) => v.scopeName;
 
@@ -179,7 +178,12 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     let currentScopeStack = scopeStack^;
     let patterns = ScopeStack.activePatterns(currentScopeStack);
 
-    prerr_endline ("Index: " ++ string_of_int(i) ++ " - scopes: " ++ ScopeStack.show(currentScopeStack));
+    prerr_endline(
+      "Index: "
+      ++ string_of_int(i)
+      ++ " - scopes: "
+      ++ ScopeStack.show(currentScopeStack),
+    );
 
     let rules =
       Rule.ofPatterns(

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -9,8 +9,13 @@ type t = {
   repository: StringMap.t(list(Pattern.t)),
 };
 
-let getScope = (scope: string, v: t) =>
-  StringMap.find_opt(scope, v.repository);
+let getScope = (scope: string, v: t) => {
+  if (scope == "$self") {
+    Some(v.patterns)
+  } else {
+    StringMap.find_opt(scope, v.repository);
+  }
+};
 
 let getScopeName = (v: t) => v.scopeName;
 

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -151,15 +151,17 @@ module Json = {
         | _ => Ok([])
         };
 
-      let beginCaptureName = switch ((member("beginCaptures", json), member("captures", json))) {
-      | (`Assoc(_), _) => "beginCaptures"
-      | _ => "captures";
-      };
-      
-      let endCaptureName = switch ((member("endCaptures", json), member("captures", json))) {
-      | (`Assoc(_), _) => "endCaptures"
-      | _ => "captures";
-      };
+      let beginCaptureName =
+        switch (member("beginCaptures", json), member("captures", json)) {
+        | (`Assoc(_), _) => "beginCaptures"
+        | _ => "captures"
+        };
+
+      let endCaptureName =
+        switch (member("endCaptures", json), member("captures", json)) {
+        | (`Assoc(_), _) => "endCaptures"
+        | _ => "captures"
+        };
 
       Ok(
         MatchRange({

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -151,13 +151,23 @@ module Json = {
         | _ => Ok([])
         };
 
+      let beginCaptureName = switch ((member("beginCaptures", json), member("captures", json))) {
+      | (`Assoc(_), _) => "beginCaptures"
+      | _ => "captures";
+      };
+      
+      let endCaptureName = switch ((member("endCaptures", json), member("captures", json))) {
+      | (`Assoc(_), _) => "endCaptures"
+      | _ => "captures";
+      };
+
       Ok(
         MatchRange({
           matchScopeName: name,
           beginRegex,
           endRegex,
-          beginCaptures: captures_of_yojson(member("beginCaptures", json)),
-          endCaptures: captures_of_yojson(member("endCaptures", json)),
+          beginCaptures: captures_of_yojson(member(beginCaptureName, json)),
+          endCaptures: captures_of_yojson(member(endCaptureName, json)),
           patterns: nestedPatterns,
         }),
       );

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -65,18 +65,16 @@ let rec ofPatterns = (~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
       }
     };
   };
-  
-   let rules = List.fold_left(f, [], patterns);
-  
-    switch (ScopeStack.activeRange(scopeStack)) {
-    | Some(v) => [ofMatchRangeEnd(v), ...rules]
-    | None => rules
-    };
 
+  let rules = List.fold_left(f, [], patterns);
+
+  switch (ScopeStack.activeRange(scopeStack)) {
+  | Some(v) => [ofMatchRangeEnd(v), ...rules]
+  | None => rules
+  };
   /*let initialList =
     switch (ScopeStack.activeRange(scopeStack)) {
     | Some(v) => [ofMatchRangeEnd(v)]
     | None => []
     };*/
-
 };

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -65,12 +65,18 @@ let rec ofPatterns = (~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
       }
     };
   };
+  
+   let rules = List.fold_left(f, [], patterns);
+  
+    switch (ScopeStack.activeRange(scopeStack)) {
+    | Some(v) => [ofMatchRangeEnd(v), ...rules]
+    | None => rules
+    };
 
-  let initialList =
+  /*let initialList =
     switch (ScopeStack.activeRange(scopeStack)) {
     | Some(v) => [ofMatchRangeEnd(v)]
     | None => []
-    };
+    };*/
 
-  List.fold_left(f, initialList, patterns);
 };

--- a/src/ScopeStack.re
+++ b/src/ScopeStack.re
@@ -15,12 +15,16 @@ let ofTopLevelScope = (patterns, scopeName) => {
 };
 
 let show = (v: t) => {
-  List.fold_left((prev, curr: Pattern.matchRange) => {
+  List.fold_left(
+    (prev, curr: Pattern.matchRange) => {
       switch (curr.matchScopeName) {
       | None => " .. " ++ prev
       | Some(v) => v ++ " " ++ prev
       }
-  }, "", v.scopes);
+    },
+    "",
+    v.scopes,
+  );
 };
 
 let activeRange = (v: t) => {

--- a/src/ScopeStack.re
+++ b/src/ScopeStack.re
@@ -14,6 +14,15 @@ let ofTopLevelScope = (patterns, scopeName) => {
   {initialScopeName: scopeName, initialPatterns: patterns, scopes: []};
 };
 
+let show = (v: t) => {
+  List.fold_left((prev, curr: Pattern.matchRange) => {
+      switch (curr.matchScopeName) {
+      | None => " .. " ++ prev
+      | Some(v) => v ++ " " ++ prev
+      }
+  }, "", v.scopes);
+};
+
 let activeRange = (v: t) => {
   switch (v.scopes) {
   | [hd, ..._] => Some(hd)
@@ -37,7 +46,7 @@ let getScopes = (v: t) => {
       }
     },
     [v.initialScopeName],
-    v.scopes,
+    v.scopes |> List.rev,
   );
 };
 

--- a/src/Token.re
+++ b/src/Token.re
@@ -73,7 +73,7 @@ let ofMatch =
   | v =>
     let initialMatch = matches[0];
 
-    /*prerr_endline(
+    prerr_endline(
         "INITIALMATCH - |"
         ++ initialMatch.match
         ++ "|"
@@ -82,7 +82,7 @@ let ofMatch =
         ++ string_of_int(initialMatch.endPos)
         ++ " length: "
         ++ string_of_int(initialMatch.length),
-      );*/
+      );
 
     /*If the rule is a 'push stack', the outer rule has already been applied
           because the scope stack has been updated.
@@ -119,7 +119,7 @@ let ofMatch =
       cg => {
         let (idx, scope) = cg;
         let match = matches[idx];
-        /*prerr_endline(
+        prerr_endline(
             " --MATCH - |"
             ++ match.match
             ++ "|"
@@ -128,7 +128,7 @@ let ofMatch =
             ++ string_of_int(match.endPos)
             ++ " length: "
             ++ string_of_int(match.length),
-          );*/
+          );
 
         if (match.length > 0 && match.startPos < initialMatch.endPos) {
           let idx = ref(match.startPos - initialMatch.startPos);

--- a/src/Token.re
+++ b/src/Token.re
@@ -73,7 +73,7 @@ let ofMatch =
   | v =>
     let initialMatch = matches[0];
 
-    prerr_endline(
+    /*prerr_endline(
       "INITIALMATCH - |"
       ++ initialMatch.match
       ++ "|"
@@ -82,7 +82,7 @@ let ofMatch =
       ++ string_of_int(initialMatch.endPos)
       ++ " length: "
       ++ string_of_int(initialMatch.length),
-    );
+    );*/
 
     /*If the rule is a 'push stack', the outer rule has already been applied
           because the scope stack has been updated.
@@ -119,7 +119,7 @@ let ofMatch =
       cg => {
         let (idx, scope) = cg;
         let match = matches[idx];
-        prerr_endline(
+        /*prerr_endline(
           " --MATCH - |"
           ++ match.match
           ++ "|"
@@ -128,7 +128,7 @@ let ofMatch =
           ++ string_of_int(match.endPos)
           ++ " length: "
           ++ string_of_int(match.length),
-        );
+        );*/
 
         if (match.length > 0 && match.startPos < initialMatch.endPos) {
           let idx = ref(match.startPos - initialMatch.startPos);

--- a/src/Token.re
+++ b/src/Token.re
@@ -74,15 +74,15 @@ let ofMatch =
     let initialMatch = matches[0];
 
     /*prerr_endline(
-      "INITIALMATCH - |"
-      ++ initialMatch.match
-      ++ "|"
-      ++ string_of_int(initialMatch.startPos)
-      ++ "-"
-      ++ string_of_int(initialMatch.endPos)
-      ++ " length: "
-      ++ string_of_int(initialMatch.length),
-    );*/
+        "INITIALMATCH - |"
+        ++ initialMatch.match
+        ++ "|"
+        ++ string_of_int(initialMatch.startPos)
+        ++ "-"
+        ++ string_of_int(initialMatch.endPos)
+        ++ " length: "
+        ++ string_of_int(initialMatch.length),
+      );*/
 
     /*If the rule is a 'push stack', the outer rule has already been applied
           because the scope stack has been updated.
@@ -120,15 +120,15 @@ let ofMatch =
         let (idx, scope) = cg;
         let match = matches[idx];
         /*prerr_endline(
-          " --MATCH - |"
-          ++ match.match
-          ++ "|"
-          ++ string_of_int(match.startPos)
-          ++ "-"
-          ++ string_of_int(match.endPos)
-          ++ " length: "
-          ++ string_of_int(match.length),
-        );*/
+            " --MATCH - |"
+            ++ match.match
+            ++ "|"
+            ++ string_of_int(match.startPos)
+            ++ "-"
+            ++ string_of_int(match.endPos)
+            ++ " length: "
+            ++ string_of_int(match.length),
+          );*/
 
         if (match.length > 0 && match.startPos < initialMatch.endPos) {
           let idx = ref(match.startPos - initialMatch.startPos);

--- a/src/Token.re
+++ b/src/Token.re
@@ -74,15 +74,15 @@ let ofMatch =
     let initialMatch = matches[0];
 
     prerr_endline(
-        "INITIALMATCH - |"
-        ++ initialMatch.match
-        ++ "|"
-        ++ string_of_int(initialMatch.startPos)
-        ++ "-"
-        ++ string_of_int(initialMatch.endPos)
-        ++ " length: "
-        ++ string_of_int(initialMatch.length),
-      );
+      "INITIALMATCH - |"
+      ++ initialMatch.match
+      ++ "|"
+      ++ string_of_int(initialMatch.startPos)
+      ++ "-"
+      ++ string_of_int(initialMatch.endPos)
+      ++ " length: "
+      ++ string_of_int(initialMatch.length),
+    );
 
     /*If the rule is a 'push stack', the outer rule has already been applied
           because the scope stack has been updated.
@@ -120,15 +120,15 @@ let ofMatch =
         let (idx, scope) = cg;
         let match = matches[idx];
         prerr_endline(
-            " --MATCH - |"
-            ++ match.match
-            ++ "|"
-            ++ string_of_int(match.startPos)
-            ++ "-"
-            ++ string_of_int(match.endPos)
-            ++ " length: "
-            ++ string_of_int(match.length),
-          );
+          " --MATCH - |"
+          ++ match.match
+          ++ "|"
+          ++ string_of_int(match.startPos)
+          ++ "-"
+          ++ string_of_int(match.endPos)
+          ++ " length: "
+          ++ string_of_int(match.length),
+        );
 
         if (match.length > 0 && match.startPos < initialMatch.endPos) {
           let idx = ref(match.startPos - initialMatch.startPos);

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -373,5 +373,85 @@
 			"fixtures/python-regex.json"
 		],
 		"desc": "TEST #9"
+	},
+	{
+		"grammarScopeName": "source.coffee",
+		"lines": [
+			{
+				"line": "\"the value is #{@x} my friend\"",
+				"tokens": [
+					{
+						"value": "\"",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"punctuation.definition.string.begin.coffee"
+						]
+					},
+					{
+						"value": "the value is ",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee"
+						]
+					},
+					{
+						"value": "#{",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"punctuation.section.embedded.coffee"
+						]
+					},
+					{
+						"value": "@x",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"variable.other.readwrite.instance.coffee"
+						]
+					},
+					{
+						"value": "}",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"punctuation.section.embedded.coffee"
+						]
+					},
+					{
+						"value": " my friend",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee"
+						]
+					},
+					{
+						"value": "\"",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"punctuation.definition.string.end.coffee"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json"
+		],
+		"desc": "TEST #11"
 	}
 ]

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -453,5 +453,115 @@
 			"fixtures/python-regex.json"
 		],
 		"desc": "TEST #11"
+	},
+	{
+		"grammarScopeName": "source.coffee",
+		"lines": [
+			{
+				"line": "\"#{\"#{@x}\"}\"",
+				"tokens": [
+					{
+						"value": "\"",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"punctuation.definition.string.begin.coffee"
+						]
+					},
+					{
+						"value": "#{",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"punctuation.section.embedded.coffee"
+						]
+					},
+					{
+						"value": "\"",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"string.quoted.double.coffee",
+							"punctuation.definition.string.begin.coffee"
+						]
+					},
+					{
+						"value": "#{",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"punctuation.section.embedded.coffee"
+						]
+					},
+					{
+						"value": "@x",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"variable.other.readwrite.instance.coffee"
+						]
+					},
+					{
+						"value": "}",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"punctuation.section.embedded.coffee"
+						]
+					},
+					{
+						"value": "\"",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"string.quoted.double.coffee",
+							"punctuation.definition.string.end.coffee"
+						]
+					},
+					{
+						"value": "}",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"source.coffee.embedded.source",
+							"punctuation.section.embedded.coffee"
+						]
+					},
+					{
+						"value": "\"",
+						"scopes": [
+							"source.coffee",
+							"string.quoted.double.coffee",
+							"punctuation.definition.string.end.coffee"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json"
+		],
+		"desc": "TEST #12"
 	}
 ]


### PR DESCRIPTION
There were a few bugs causing test cases 11 & 12 to fail:
- Scopes were being presented in the wrong order
- The `$self` include was not being handled correctly
- begin/end rules with `captures` was not handled correctly (we were expecting `beginCaptures` and `endCaptures`)