### PR TITLE
Handle 'applyEndPatternLast'

### DIFF
--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -190,17 +190,10 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     | Some(v) => v
     };
 
-  // Empty string - just return a single, zero-length token, and persist the scope stack.
-  if (len == 0) {
-    (
-      [Token.create(~position=0, ~length=0, ~scopeStack=initialScope, ())],
-      initialScope,
-    );
-  } else {
     let scopeStack = ref(initialScope);
 
     // Iterate across the string and tokenize
-    while (idx^ < len) {
+    while (idx^ <= len) {
       let i = idx^;
 
       let currentScopeStack = scopeStack^;
@@ -323,7 +316,15 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     // There might be some leftover whitespace or tokens
     // that weren't processed through our loop iteration.
     let tokens =
-      if (lastTokenPosition^ < len) {
+      if (len == 0) {
+        [[Token.create(
+        ~position=0,
+        ~length=0,
+        ~scopeStack=scopeStack^,
+        (),
+                )]]
+      }
+      else if (lastTokenPosition^ < len) {
         [
           [
             Token.create(
@@ -344,5 +345,4 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     let scopeStack = scopeStack^;
 
     (retTokens, scopeStack);
-  };
 };

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -190,159 +190,153 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     | Some(v) => v
     };
 
-    let scopeStack = ref(initialScope);
+  let scopeStack = ref(initialScope);
 
-    // Iterate across the string and tokenize
-    while (idx^ <= len) {
-      let i = idx^;
+  // Iterate across the string and tokenize
+  while (idx^ <= len) {
+    let i = idx^;
 
-      let currentScopeStack = scopeStack^;
+    let currentScopeStack = scopeStack^;
 
-      // Get active set of patterns...
-      let patterns = ScopeStack.activePatterns(currentScopeStack);
+    // Get active set of patterns...
+    let patterns = ScopeStack.activePatterns(currentScopeStack);
 
-      prerr_endline(
-        "Index: "
-        ++ string_of_int(i)
-        ++ " - scopes: "
-        ++ ScopeStack.show(currentScopeStack),
+    prerr_endline(
+      "Index: "
+      ++ string_of_int(i)
+      ++ " - scopes: "
+      ++ ScopeStack.show(currentScopeStack),
+    );
+
+    // ...and then get rules from the patterns.
+    let rules =
+      Rule.ofPatterns(
+        ~getScope=v => getScope(v, grammar),
+        ~scopeStack=currentScopeStack,
+        patterns,
       );
 
-      // ...and then get rules from the patterns.
-      let rules =
-        Rule.ofPatterns(
-          ~getScope=v => getScope(v, grammar),
-          ~scopeStack=currentScopeStack,
-          patterns,
-        );
+    // And figure out if any of the rules applies.
+    let bestRule = _getBestRule(rules, line, i);
 
-      // And figure out if any of the rules applies.
-      let bestRule = _getBestRule(rules, line, i);
-
-      switch (bestRule) {
-      // No matching rule... just increment position and try again
-      | None => incr(idx)
-      // Got a matching rule!
-      | Some(v) =>
-        open Oniguruma.OnigRegExp.Match;
-        let (_, matches, rule) = v;
-        prerr_endline("Winning rule: " ++ Rule.show(rule));
-        let ltp = lastTokenPosition^;
-        let prevToken =
-          if (ltp < matches[0].startPos) {
-            print_endline("Creating token at: " ++ string_of_int(ltp));
-            [
-              Token.create(
-                ~position=ltp,
-                ~length=matches[0].startPos - ltp,
-                ~scopeStack=scopeStack^,
-                (),
-              ),
-            ];
-          } else {
-            [];
-          };
-
-        switch (rule.pushStack) {
-        // If there is nothing to push... nothing to worry about
-        | None => ()
-        | Some(matchRange) =>
-          print_endline("Adding scope...");
-          scopeStack :=
-            ScopeStack.pushPattern(
-              ~matches,
-              ~matchRange,
-              ~line=lineNumber,
-              scopeStack^,
-            );
-
-          switch (matchRange.name) {
-          | None => ()
-          | Some(n) => scopeStack := ScopeStack.pushScope(n, scopeStack^)
-          };
-        };
-
-        switch (rule.popStack) {
-        | None => ()
-        | Some(mr) =>
-          switch (mr.contentName) {
-          | None => ()
-          | Some(_) => scopeStack := ScopeStack.popScope(scopeStack^)
-          }
-        };
-
-        print_endline(
-          " -- match: "
-          ++ string_of_int(matches[0].startPos)
-          ++ "-"
-          ++ string_of_int(matches[0].endPos),
-        );
-        // Only add token if there was actually a match!
-        if (matches[0].endPos > matches[0].startPos) {
-          tokens :=
-            [
-              Token.ofMatch(~matches, ~rule, ~scopeStack=scopeStack^, ()),
-              prevToken,
-              ...tokens^,
-            ];
-          lastTokenPosition := matches[0].endPos;
-        };
-
-        switch (rule.pushStack) {
-        // If there is nothing to push... nothing to worry about
-        | None => ()
-        | Some(matchRange) =>
-          switch (matchRange.contentName) {
-          | None => ()
-          | Some(n) => scopeStack := ScopeStack.pushScope(n, scopeStack^)
-          }
-        };
-
-        switch (rule.popStack) {
-        | None => ()
-        | Some(mr) =>
-          scopeStack := ScopeStack.popPattern(scopeStack^);
-          switch (mr.name) {
-          | None => ()
-          | Some(_) => scopeStack := ScopeStack.popScope(scopeStack^)
-          };
-        };
-
-        let prevIndex = idx^;
-        idx := max(matches[0].endPos, prevIndex);
-      };
-    };
-
-    // There might be some leftover whitespace or tokens
-    // that weren't processed through our loop iteration.
-    let tokens =
-      if (len == 0) {
-        [[Token.create(
-        ~position=0,
-        ~length=0,
-        ~scopeStack=scopeStack^,
-        (),
-                )]]
-      }
-      else if (lastTokenPosition^ < len) {
-        [
+    switch (bestRule) {
+    // No matching rule... just increment position and try again
+    | None => incr(idx)
+    // Got a matching rule!
+    | Some(v) =>
+      open Oniguruma.OnigRegExp.Match;
+      let (_, matches, rule) = v;
+      prerr_endline("Winning rule: " ++ Rule.show(rule));
+      let ltp = lastTokenPosition^;
+      let prevToken =
+        if (ltp < matches[0].startPos) {
+          print_endline("Creating token at: " ++ string_of_int(ltp));
           [
             Token.create(
-              ~position=lastTokenPosition^,
-              ~length=len - lastTokenPosition^,
+              ~position=ltp,
+              ~length=matches[0].startPos - ltp,
               ~scopeStack=scopeStack^,
               (),
             ),
-          ],
-          ...tokens^,
-        ];
-      } else {
-        tokens^;
+          ];
+        } else {
+          [];
+        };
+
+      switch (rule.pushStack) {
+      // If there is nothing to push... nothing to worry about
+      | None => ()
+      | Some(matchRange) =>
+        print_endline("Adding scope...");
+        scopeStack :=
+          ScopeStack.pushPattern(
+            ~matches,
+            ~matchRange,
+            ~line=lineNumber,
+            scopeStack^,
+          );
+
+        switch (matchRange.name) {
+        | None => ()
+        | Some(n) => scopeStack := ScopeStack.pushScope(n, scopeStack^)
+        };
       };
 
-    let retTokens = tokens |> List.rev |> List.flatten;
+      switch (rule.popStack) {
+      | None => ()
+      | Some(mr) =>
+        switch (mr.contentName) {
+        | None => ()
+        | Some(_) => scopeStack := ScopeStack.popScope(scopeStack^)
+        }
+      };
 
-    let scopeStack = scopeStack^;
+      print_endline(
+        " -- match: "
+        ++ string_of_int(matches[0].startPos)
+        ++ "-"
+        ++ string_of_int(matches[0].endPos),
+      );
+      // Only add token if there was actually a match!
+      if (matches[0].endPos > matches[0].startPos) {
+        tokens :=
+          [
+            Token.ofMatch(~matches, ~rule, ~scopeStack=scopeStack^, ()),
+            prevToken,
+            ...tokens^,
+          ];
+        lastTokenPosition := matches[0].endPos;
+      };
 
-    (retTokens, scopeStack);
+      switch (rule.pushStack) {
+      // If there is nothing to push... nothing to worry about
+      | None => ()
+      | Some(matchRange) =>
+        switch (matchRange.contentName) {
+        | None => ()
+        | Some(n) => scopeStack := ScopeStack.pushScope(n, scopeStack^)
+        }
+      };
+
+      switch (rule.popStack) {
+      | None => ()
+      | Some(mr) =>
+        scopeStack := ScopeStack.popPattern(scopeStack^);
+        switch (mr.name) {
+        | None => ()
+        | Some(_) => scopeStack := ScopeStack.popScope(scopeStack^)
+        };
+      };
+
+      let prevIndex = idx^;
+      idx := max(matches[0].endPos, prevIndex);
+    };
+  };
+
+  // There might be some leftover whitespace or tokens
+  // that weren't processed through our loop iteration.
+  let tokens =
+    if (len == 0) {
+      [[Token.create(~position=0, ~length=0, ~scopeStack=scopeStack^, ())]];
+    } else if (lastTokenPosition^ < len) {
+      [
+        [
+          Token.create(
+            ~position=lastTokenPosition^,
+            ~length=len - lastTokenPosition^,
+            ~scopeStack=scopeStack^,
+            (),
+          ),
+        ],
+        ...tokens^,
+      ];
+    } else {
+      tokens^;
+    };
+
+  let retTokens = tokens |> List.rev |> List.flatten;
+
+  let scopeStack = scopeStack^;
+
+  (retTokens, scopeStack);
 };

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -69,11 +69,12 @@ module Json = {
       };
     };
 
-  let bool_of_yojson: Yojson.Safe.t => bool = json => {
-    switch (json) {
-    | `Bool(v) => v
-    | _ => false
-        };
+  let bool_of_yojson: Yojson.Safe.t => bool =
+    json => {
+      switch (json) {
+      | `Bool(v) => v
+      | _ => false
+      };
     };
 
   let captures_of_yojson: Yojson.Safe.t => list(Capture.t) =
@@ -160,7 +161,8 @@ module Json = {
       open Yojson.Safe.Util;
       let%bind beginRegex = regex_of_yojson(member("begin", json));
       let%bind endRegex = regex_of_yojson(member("end", json));
-      let applyEndPatternLast = bool_of_yojson(member("applyEndPatternLast", json));
+      let applyEndPatternLast =
+        bool_of_yojson(member("applyEndPatternLast", json));
 
       let name =
         switch (string_of_yojson("name", json)) {

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -26,6 +26,7 @@ and matchRange = {
   // impacts matches _between_ the tokens.
   contentName: option(string),
   patterns: list(t),
+  applyEndPatternLast: bool,
 };
 
 let show = (v: t) =>
@@ -66,6 +67,13 @@ module Json = {
       | `String(v) => Ok(v)
       | _ => Error("Missing expected property: " ++ memberName)
       };
+    };
+
+  let bool_of_yojson: Yojson.Safe.t => bool = json => {
+    switch (json) {
+    | `Bool(v) => v
+    | _ => false
+        };
     };
 
   let captures_of_yojson: Yojson.Safe.t => list(Capture.t) =
@@ -152,6 +160,7 @@ module Json = {
       open Yojson.Safe.Util;
       let%bind beginRegex = regex_of_yojson(member("begin", json));
       let%bind endRegex = regex_of_yojson(member("end", json));
+      let applyEndPatternLast = bool_of_yojson(member("applyEndPatternLast", json));
 
       let name =
         switch (string_of_yojson("name", json)) {
@@ -199,6 +208,7 @@ module Json = {
 
       Ok(
         MatchRange({
+          applyEndPatternLast,
           name,
           beginRegex,
           endRegex,

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -71,15 +71,19 @@ let rec ofPatterns = (~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
 
   let activeRange = ScopeStack.activeRange(scopeStack);
 
-  let initialRules = switch(activeRange) {
-  | Some(v) when v.applyEndPatternLast == true => [ofMatchRangeEnd(v)]
-  | _ => [];
-    }
+  let initialRules =
+    switch (activeRange) {
+    | Some(v) when v.applyEndPatternLast == true => [ofMatchRangeEnd(v)]
+    | _ => []
+    };
 
   let rules = List.fold_left(f, initialRules, patterns);
 
   switch (activeRange) {
-  | Some(v) when v.applyEndPatternLast == false => [ofMatchRangeEnd(v), ...rules]
+  | Some(v) when v.applyEndPatternLast == false => [
+      ofMatchRangeEnd(v),
+      ...rules,
+    ]
   | _ => rules
   };
 };

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -69,10 +69,17 @@ let rec ofPatterns = (~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
     };
   };
 
-  let rules = List.fold_left(f, [], patterns);
+  let activeRange = ScopeStack.activeRange(scopeStack);
 
-  switch (ScopeStack.activeRange(scopeStack)) {
-  | Some(v) => [ofMatchRangeEnd(v), ...rules]
-  | None => rules
+  let initialRules = switch(activeRange) {
+  | Some(v) when v.applyEndPatternLast == true => [ofMatchRangeEnd(v)]
+  | _ => [];
+    }
+
+  let rules = List.fold_left(f, initialRules, patterns);
+
+  switch (activeRange) {
+  | Some(v) when v.applyEndPatternLast == false => [ofMatchRangeEnd(v), ...rules]
+  | _ => rules
   };
 };

--- a/test/GrammarCaptureTests.re
+++ b/test/GrammarCaptureTests.re
@@ -40,6 +40,7 @@ describe("GrammarCaptureTests", ({test, _}) => {
           name: Some("html.tag.contents"),
           contentName: None,
           patterns: [],
+          applyEndPatternLast: false,
         }),
       ],
       ~repository=[],

--- a/test/GrammarTests.re
+++ b/test/GrammarTests.re
@@ -98,6 +98,7 @@ describe("Grammar", ({describe, _}) => {
               name: Some("expression.group"),
               contentName: None,
               patterns: [Include("#expression")],
+              applyEndPatternLast: false,
             }),
           ],
         ),

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -1169,5 +1169,183 @@
 			"fixtures/apply-end-pattern-last.json"
 		],
 		"desc": "TEST #24"
+	},
+	{
+		"grammarScopeName": "source.ruby",
+		"lines": [
+			{
+				"line": "%w|oh|,",
+				"tokens": [
+					{
+						"value": "%w|",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.lower.ruby",
+							"punctuation.definition.string.begin.ruby"
+						]
+					},
+					{
+						"value": "oh",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.lower.ruby"
+						]
+					},
+					{
+						"value": "|",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.lower.ruby",
+							"punctuation.definition.string.end.ruby"
+						]
+					},
+					{
+						"value": ",",
+						"scopes": [
+							"source.ruby",
+							"punctuation.separator.object.ruby"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json"
+		],
+		"desc": "TEST #25"
+	},
+	{
+		"grammarScopeName": "source.ruby",
+		"lines": [
+			{
+				"line": "%Q+matz had some #{%Q-crazy ideas-} for ruby syntax+ # damn.",
+				"tokens": [
+					{
+						"value": "%Q+",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"punctuation.definition.string.begin.ruby"
+						]
+					},
+					{
+						"value": "matz had some ",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby"
+						]
+					},
+					{
+						"value": "#{",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"meta.embedded.line.ruby",
+							"punctuation.section.embedded.begin.ruby"
+						]
+					},
+					{
+						"value": "%Q-",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"meta.embedded.line.ruby",
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"punctuation.definition.string.begin.ruby"
+						]
+					},
+					{
+						"value": "crazy ideas",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"meta.embedded.line.ruby",
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby"
+						]
+					},
+					{
+						"value": "-",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"meta.embedded.line.ruby",
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"punctuation.definition.string.end.ruby"
+						]
+					},
+					{
+						"value": "}",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"meta.embedded.line.ruby",
+							"punctuation.section.embedded.end.ruby",
+							"source.ruby"
+						]
+					},
+					{
+						"value": " for ruby syntax",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby"
+						]
+					},
+					{
+						"value": "+",
+						"scopes": [
+							"source.ruby",
+							"string.quoted.other.literal.upper.ruby",
+							"punctuation.definition.string.end.ruby"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.ruby"
+						]
+					},
+					{
+						"value": "#",
+						"scopes": [
+							"source.ruby",
+							"comment.line.number-sign.ruby",
+							"punctuation.definition.comment.ruby"
+						]
+					},
+					{
+						"value": " damn.",
+						"scopes": [
+							"source.ruby",
+							"comment.line.number-sign.ruby"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json"
+		],
+		"desc": "TEST #26"
 	}
 ]

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -1033,5 +1033,141 @@
 			"fixtures/python-regex.json"
 		],
 		"desc": "TEST #23"
+	},
+	{
+		"grammarPath": "fixtures/apply-end-pattern-last.json",
+		"lines": [
+			{
+				"line": "last",
+				"tokens": [
+					{
+						"value": "last",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"end-pattern-last-env"
+						]
+					}
+				]
+			},
+			{
+				"line": "{ some }excentricSyntax }",
+				"tokens": [
+					{
+						"value": "{",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"end-pattern-last-env",
+							"scope"
+						]
+					},
+					{
+						"value": " some ",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"end-pattern-last-env",
+							"scope"
+						]
+					},
+					{
+						"value": "}excentricSyntax",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"end-pattern-last-env",
+							"scope",
+							"excentric"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"end-pattern-last-env",
+							"scope"
+						]
+					},
+					{
+						"value": "}",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"end-pattern-last-env",
+							"scope"
+						]
+					}
+				]
+			},
+			{
+				"line": "",
+				"tokens": [
+					{
+						"value": "",
+						"scopes": [
+							"source.apply-end-pattern-last"
+						]
+					}
+				]
+			},
+			{
+				"line": "first",
+				"tokens": [
+					{
+						"value": "first",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"normal-env"
+						]
+					}
+				]
+			},
+			{
+				"line": "{ some }excentricSyntax }",
+				"tokens": [
+					{
+						"value": "{",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"normal-env",
+							"scope"
+						]
+					},
+					{
+						"value": " some ",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"normal-env",
+							"scope"
+						]
+					},
+					{
+						"value": "}",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"normal-env",
+							"scope"
+						]
+					},
+					{
+						"value": "excentricSyntax }",
+						"scopes": [
+							"source.apply-end-pattern-last",
+							"normal-env"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json",
+			"fixtures/apply-end-pattern-last.json"
+		],
+		"desc": "TEST #24"
 	}
 ]


### PR DESCRIPTION
Capture ranges have an `applyEndPatternLast` option. By default, the `end` regex is tested _first_ - but if `applyEndPatternLast` is specified, it should be tested _after_ other rules.