### PR TITLE
Feature: Handle a anchor

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -4,8 +4,8 @@ steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '8.9'
-  - script: npm install -g esy@0.5.7
-    displayName: 'npm install -g esy@0.5.7'
+  - script: npm install -g esy@0.5.8
+    displayName: 'npm install -g esy@0.5.8'
   - script: esy install
     displayName: 'esy install'
   - script: esy build

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -161,8 +161,10 @@ let _getBestRule = (lastMatchedRange, rules: list(Rule.t), str, position) => {
     | Some((pos, matchRange)) when pos == position =>
       let filter = (rule: Rule.t) =>
         switch (rule.popStack, rule.pushStack) {
-        | (Some(mr), _) when mr === matchRange => false
-        | (_, Some(mr)) when mr === matchRange => false
+        | (Some(mr), _) when mr === matchRange => 
+            false
+        | (_, Some(mr)) when mr === matchRange => 
+          false
         | _ => true
         };
       List.filter(filter, rules);
@@ -173,6 +175,8 @@ let _getBestRule = (lastMatchedRange, rules: list(Rule.t), str, position) => {
     (prev, curr: Rule.t) => {
       let matches = RegExp.search(str, position, curr.regex);
       let matchPos = Array.length(matches) > 0 ? matches[0].startPos : (-1);
+
+      prerr_endline ("Checking rule: " ++ Rule.show(curr));
 
       switch (prev) {
       | None when matchPos == (-1) => None
@@ -223,6 +227,7 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     // ...and then get rules from the patterns.
     let rules =
       Rule.ofPatterns(
+        ~isFirstLine=lineNumber==0,
         ~getScope=v => getScope(v, grammar),
         ~scopeStack=currentScopeStack,
         patterns,
@@ -238,6 +243,7 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     | Some(v) =>
       open Oniguruma.OnigRegExp.Match;
       let (_, matches, rule) = v;
+      prerr_endline ("Matching rule at " ++ string_of_int(i) ++ ": " ++ Rule.show(rule));
       let ltp = lastTokenPosition^;
       let prevToken =
         if (ltp < matches[0].startPos) {

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -176,8 +176,6 @@ let _getBestRule = (lastMatchedRange, rules: list(Rule.t), str, position) => {
       let matches = RegExp.search(str, position, curr.regex);
       let matchPos = Array.length(matches) > 0 ? matches[0].startPos : (-1);
 
-      prerr_endline ("Checking rule: " ++ Rule.show(curr));
-
       switch (prev) {
       | None when matchPos == (-1) => None
       | None => Some((matchPos, matches, curr))
@@ -243,7 +241,6 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     | Some(v) =>
       open Oniguruma.OnigRegExp.Match;
       let (_, matches, rule) = v;
-      prerr_endline ("Matching rule at " ++ string_of_int(i) ++ ": " ++ Rule.show(rule));
       let ltp = lastTokenPosition^;
       let prevToken =
         if (ltp < matches[0].startPos) {

--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -161,10 +161,8 @@ let _getBestRule = (lastMatchedRange, rules: list(Rule.t), str, position) => {
     | Some((pos, matchRange)) when pos == position =>
       let filter = (rule: Rule.t) =>
         switch (rule.popStack, rule.pushStack) {
-        | (Some(mr), _) when mr === matchRange => 
-            false
-        | (_, Some(mr)) when mr === matchRange => 
-          false
+        | (Some(mr), _) when mr === matchRange => false
+        | (_, Some(mr)) when mr === matchRange => false
         | _ => true
         };
       List.filter(filter, rules);
@@ -225,7 +223,7 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     // ...and then get rules from the patterns.
     let rules =
       Rule.ofPatterns(
-        ~isFirstLine=lineNumber==0,
+        ~isFirstLine=lineNumber == 0,
         ~getScope=v => getScope(v, grammar),
         ~scopeStack=currentScopeStack,
         patterns,

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -11,13 +11,13 @@ type t =
   | Match(match_)
   | MatchRange(matchRange)
 and match = {
-  matchRegex: RegExp.t,
+  matchRegex: RegExpFactory.t,
   matchName: option(string),
   captures: list(Capture.t),
 }
 and matchRange = {
-  beginRegex: RegExp.t,
-  endRegex: RegExp.t,
+  beginRegex: RegExpFactory.t,
+  endRegex: RegExpFactory.t,
   beginCaptures: list(Capture.t),
   endCaptures: list(Capture.t),
   // The scope to append to the tokens
@@ -53,10 +53,10 @@ let show = (v: t) =>
     ++ contentName
     ++ "\n"
     ++ " -"
-    ++ RegExp.toString(matchRange.beginRegex)
+    ++ RegExpFactory.show(matchRange.beginRegex)
     ++ "\n"
     ++ " -"
-    ++ RegExp.toString(matchRange.endRegex)
+    ++ RegExpFactory.show(matchRange.endRegex)
     ++ "\n";
   };
 
@@ -108,10 +108,10 @@ module Json = {
       };
     };
 
-  let regex_of_yojson: Yojson.Safe.t => result(RegExp.t, string) =
+  let regex_of_yojson: Yojson.Safe.t => result(RegExpFactory.t, string) =
     json => {
       switch (json) {
-      | `String(v) => RegExp.create(v)
+      | `String(v) => Ok(RegExpFactory.create(v))
       | _ => Error("Regular expression not specified")
       };
     };

--- a/src/RegExp.re
+++ b/src/RegExp.re
@@ -14,6 +14,7 @@ type t = {
   regexp: option(OnigRegExp.t),
 };
 
+let raw = (v: t) => v.raw;
 let toString = (v: t) => v.raw;
 
 let emptyMatches = [||];

--- a/src/RegExp.re
+++ b/src/RegExp.re
@@ -19,16 +19,14 @@ let toString = (v: t) => v.raw;
 let emptyMatches = [||];
 
 let create = (str: string) => {
-  let regexp = switch (OnigRegExp.create(str)) {
-  | Ok(v) => Some(v)
-  | Error(msg) => failwith(msg);
+  let regexp =
+    switch (OnigRegExp.create(str)) {
+    | Ok(v) => Some(v)
+    | Error(msg) => failwith(msg)
     };
 
-  {
-    raw: str,
-    regexp
-    }
-}
+  {raw: str, regexp};
+};
 
 let search = (str: string, position: int, v: t) => {
   switch (v.regexp) {

--- a/src/RegExp.re
+++ b/src/RegExp.re
@@ -9,90 +9,26 @@
 
 open Oniguruma;
 
-type captureGroup = (int, string);
-
 type t = {
-  hasBackReferences: bool,
-  captureGroups: option(list(captureGroup)),
   raw: string,
   regexp: option(OnigRegExp.t),
 };
 
-let hasBackRefRegExp = Str.regexp("\\\\\\([0-9]+\\)");
-
-let hasBackReferences = (v: t) => v.hasBackReferences;
-
 let toString = (v: t) => v.raw;
 
-let charactersToEscape = Str.regexp("[\\?\\,\\.\\$\\^\\+\\*{}\\\\\\|\\-]");
-let additionalCharactersToEscape = Str.regexp("[][()]");
-let escapeRegExpCharacters = (str: string) => {
-  let f = s => "\\" ++ s;
-
-  str
-  |> Str.global_substitute(charactersToEscape, f)
-  |> Str.global_substitute(additionalCharactersToEscape, f);
-};
-
-let create = (regExString: string) => {
-  let hasBackReferences =
-    switch (Str.search_forward(hasBackRefRegExp, regExString, 0)) {
-    | exception _ => false
-    | _ => true
-    };
-
-  switch (hasBackReferences) {
-  | false =>
-    let%bind regexp = OnigRegExp.create(regExString);
-    Ok({
-      hasBackReferences: false,
-      captureGroups: None,
-      raw: regExString,
-      regexp: Some(regexp),
-    });
-  | true =>
-    Ok({
-      hasBackReferences: true,
-      captureGroups: None,
-      raw: regExString,
-      regexp: None,
-    })
-  };
-};
-
-let supplyReferences = (references: list(captureGroup), v: t) => {
-  let newRawStr =
-    List.fold_left(
-      (prev, curr) => {
-        let (cg, text) = curr;
-        let str = prev;
-
-        let newStr =
-          if (cg > 0) {
-            let regexp = Str.regexp("\\\\" ++ string_of_int(cg));
-            let text = escapeRegExpCharacters(text);
-            Str.global_replace(regexp, text, str);
-          } else {
-            prev;
-          };
-
-        newStr;
-      },
-      v.raw,
-      references,
-    );
-
-  let regexp =
-    switch (OnigRegExp.create(newRawStr)) {
-    | Ok(v) => v
-    | Error(msg) =>
-      failwith("Error creating regex: " ++ newRawStr ++ " - " ++ msg)
-    };
-
-  {...v, hasBackReferences: false, raw: newRawStr, regexp: Some(regexp)};
-};
-
 let emptyMatches = [||];
+
+let create = (str: string) => {
+  let regexp = switch (OnigRegExp.create(str)) {
+  | Ok(v) => Some(v)
+  | Error(msg) => failwith(msg);
+    };
+
+  {
+    raw: str,
+    regexp
+    }
+}
 
 let search = (str: string, position: int, v: t) => {
   switch (v.regexp) {

--- a/src/RegExpFactory.re
+++ b/src/RegExpFactory.re
@@ -81,7 +81,7 @@ let supplyReferences = (references: list(captureGroup), v: t) => {
   {...v, hasBackReferences: false, raw: newRawStr};
 };
 
-let getRegEx = (v: t) => switch (v.regex) {
+let compile = (v: t) => switch (v.regex) {
 | None => RegExp.create(v.raw)
 | _ => RegExp.create(v.raw)
 };

--- a/src/RegExpFactory.re
+++ b/src/RegExpFactory.re
@@ -7,9 +7,9 @@
 type captureGroup = (int, string);
 
 type anchorCache = {
-    raw_A0: string,
-    raw_A1: string,
-}
+  raw_A0: string,
+  raw_A1: string,
+};
 
 type t = {
   hasAnchorA: bool,
@@ -40,15 +40,12 @@ let escapeRegExpCharacters = (str: string) => {
 
 let _createAnchorCache = (str: string) => {
   let f = _ => "\\uFFFF";
- 
+
   let raw_A0 = Str.global_substitute(hasAnchorA, f, str);
   let raw_A1 = str;
 
-  Some({
-    raw_A0,
-    raw_A1,
-    })
-}
+  Some({raw_A0, raw_A1});
+};
 
 let create = str => {
   let hasBackReferences =
@@ -57,15 +54,17 @@ let create = str => {
     | _ => true
     };
 
-  let anchorA = switch(Str.search_forward(hasAnchorA, str, 0)) {
-  | exception _ => false
-  | _ => true
-  };
+  let anchorA =
+    switch (Str.search_forward(hasAnchorA, str, 0)) {
+    | exception _ => false
+    | _ => true
+    };
 
-  let anchorCache = if (anchorA) {
-    _createAnchorCache(str);
-  } else {
-    None;
+  let anchorCache =
+    if (anchorA) {
+      _createAnchorCache(str);
+    } else {
+      None;
     };
 
   {
@@ -111,12 +110,12 @@ let supplyReferences = (references: list(captureGroup), v: t) => {
 };
 
 let compile = (allowA, v: t) => {
-
-  let rawStr = switch ((v.anchorCache, allowA)) {
-  | (None, _) => v.raw
-  | (Some({raw_A1, _}), allowA) when allowA == true => raw_A1 
-  | (Some({raw_A0, _ }), _) => raw_A0
-  };
+  let rawStr =
+    switch (v.anchorCache, allowA) {
+    | (None, _) => v.raw
+    | (Some({raw_A1, _}), allowA) when allowA == true => raw_A1
+    | (Some({raw_A0, _}), _) => raw_A0
+    };
 
   switch (v.regex) {
   | None => RegExp.create(rawStr)

--- a/src/RegExpFactory.re
+++ b/src/RegExpFactory.re
@@ -1,0 +1,89 @@
+/*
+ RegExpFactory.re
+
+ A wrapper around RegExp, to handle anchors like \\A and \\G.
+ */
+
+type captureGroup = (int, string);
+
+type t = {
+  hasAnchorA: bool,
+  hasBackReferences: bool,
+  captureGroups: option(list(captureGroup)),
+  raw: string,
+
+  // If the regex doesn't have anchors,
+  // we can just keep a ready-to-go version around.
+  regex: option(RegExp.t),
+};
+
+let hasAnchorA = Str.regexp("\\A");
+let hasAnchors = (v: t) => v.hasAnchorA;
+
+let hasBackRefRegExp = Str.regexp("\\\\\\([0-9]+\\)");
+let hasBackReferences = (v: t) => v.hasBackReferences;
+
+let charactersToEscape = Str.regexp("[\\?\\,\\.\\$\\^\\+\\*{}\\\\\\|\\-]");
+let additionalCharactersToEscape = Str.regexp("[][()]");
+let escapeRegExpCharacters = (str: string) => {
+  let f = s => "\\" ++ s;
+
+  str
+  |> Str.global_substitute(charactersToEscape, f)
+  |> Str.global_substitute(additionalCharactersToEscape, f);
+};
+
+let create = (str) => {
+  let hasBackReferences =
+    switch (Str.search_forward(hasBackRefRegExp, str, 0)) {
+    | exception _ => false
+    | _ => true
+    };
+    
+    {
+      captureGroups: None,
+      raw: str,
+      regex: None,
+      hasAnchorA: false,
+      hasBackReferences,
+    };
+}
+
+let supplyReferences = (references: list(captureGroup), v: t) => {
+  let newRawStr =
+    List.fold_left(
+      (prev, curr) => {
+        let (cg, text) = curr;
+        let str = prev;
+
+        let newStr =
+          if (cg > 0) {
+            let regexp = Str.regexp("\\\\" ++ string_of_int(cg));
+            let text = escapeRegExpCharacters(text);
+            Str.global_replace(regexp, text, str);
+          } else {
+            prev;
+          };
+
+        newStr;
+      },
+      v.raw,
+      references,
+    );
+
+  /*let regexp =
+    switch (OnigRegExp.create(newRawStr)) {
+    | Ok(v) => v
+    | Error(msg) =>
+      failwith("Error creating regex: " ++ newRawStr ++ " - " ++ msg)
+    };*/
+
+  {...v, hasBackReferences: false, raw: newRawStr};
+};
+
+let getRegEx = (v: t) => switch (v.regex) {
+| None => RegExp.create(v.raw)
+| _ => RegExp.create(v.raw)
+};
+
+let show = (v: t) => v.raw;

--- a/src/RegExpFactory.re
+++ b/src/RegExpFactory.re
@@ -11,7 +11,6 @@ type t = {
   hasBackReferences: bool,
   captureGroups: option(list(captureGroup)),
   raw: string,
-
   // If the regex doesn't have anchors,
   // we can just keep a ready-to-go version around.
   regex: option(RegExp.t),
@@ -33,21 +32,21 @@ let escapeRegExpCharacters = (str: string) => {
   |> Str.global_substitute(additionalCharactersToEscape, f);
 };
 
-let create = (str) => {
+let create = str => {
   let hasBackReferences =
     switch (Str.search_forward(hasBackRefRegExp, str, 0)) {
     | exception _ => false
     | _ => true
     };
-    
-    {
-      captureGroups: None,
-      raw: str,
-      regex: None,
-      hasAnchorA: false,
-      hasBackReferences,
-    };
-}
+
+  {
+    captureGroups: None,
+    raw: str,
+    regex: None,
+    hasAnchorA: false,
+    hasBackReferences,
+  };
+};
 
 let supplyReferences = (references: list(captureGroup), v: t) => {
   let newRawStr =
@@ -81,9 +80,10 @@ let supplyReferences = (references: list(captureGroup), v: t) => {
   {...v, hasBackReferences: false, raw: newRawStr};
 };
 
-let compile = (v: t) => switch (v.regex) {
-| None => RegExp.create(v.raw)
-| _ => RegExp.create(v.raw)
-};
+let compile = (v: t) =>
+  switch (v.regex) {
+  | None => RegExp.create(v.raw)
+  | _ => RegExp.create(v.raw)
+  };
 
 let show = (v: t) => v.raw;

--- a/src/RegExpFactory.re
+++ b/src/RegExpFactory.re
@@ -112,14 +112,11 @@ let supplyReferences = (references: list(captureGroup), v: t) => {
 
 let compile = (allowA, v: t) => {
 
-  prerr_endline ("ALLOWA: " ++ string_of_bool(allowA));
   let rawStr = switch ((v.anchorCache, allowA)) {
   | (None, _) => v.raw
   | (Some({raw_A1, _}), allowA) when allowA == true => raw_A1 
   | (Some({raw_A0, _ }), _) => raw_A0
   };
-
-  prerr_endline ("RAWSTR: " ++ rawStr);
 
   switch (v.regex) {
   | None => RegExp.create(rawStr)

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -22,7 +22,7 @@ let show = (v: t) => {
 
 let ofMatch = (match: Pattern.match_) => {
   Some({
-    regex: match.matchRegex,
+    regex: RegExpFactory.getRegEx(match.matchRegex),
     name: match.matchName,
     captures: match.captures,
     popStack: None,
@@ -32,7 +32,7 @@ let ofMatch = (match: Pattern.match_) => {
 
 let ofMatchRangeBegin = (matchRange: Pattern.matchRange) => {
   Some({
-    regex: matchRange.beginRegex,
+    regex: RegExpFactory.getRegEx(matchRange.beginRegex),
     name: matchRange.name,
     captures: matchRange.beginCaptures,
     popStack: None,
@@ -41,7 +41,7 @@ let ofMatchRangeBegin = (matchRange: Pattern.matchRange) => {
 };
 
 let ofMatchRangeEnd = (matchRange: Pattern.matchRange) => {
-  regex: matchRange.endRegex,
+  regex: RegExpFactory.getRegEx(matchRange.endRegex),
   name: matchRange.name,
   captures: matchRange.endCaptures,
   popStack: Some(matchRange),

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -20,9 +20,9 @@ let show = (v: t) => {
   start ++ RegExp.toString(v.regex);
 };
 
-let ofMatch = (match: Pattern.match_) => {
+let ofMatch = (allowA, match: Pattern.match_) => {
   Some({
-    regex: RegExpFactory.compile(match.matchRegex),
+    regex: RegExpFactory.compile(allowA, match.matchRegex),
     name: match.matchName,
     captures: match.captures,
     popStack: None,
@@ -30,9 +30,9 @@ let ofMatch = (match: Pattern.match_) => {
   });
 };
 
-let ofMatchRangeBegin = (matchRange: Pattern.matchRange) => {
+let ofMatchRangeBegin = (allowA, matchRange: Pattern.matchRange) => {
   Some({
-    regex: RegExpFactory.compile(matchRange.beginRegex),
+    regex: RegExpFactory.compile(allowA, matchRange.beginRegex),
     name: matchRange.name,
     captures: matchRange.beginCaptures,
     popStack: None,
@@ -40,29 +40,29 @@ let ofMatchRangeBegin = (matchRange: Pattern.matchRange) => {
   });
 };
 
-let ofMatchRangeEnd = (matchRange: Pattern.matchRange) => {
-  regex: RegExpFactory.compile(matchRange.endRegex),
+let ofMatchRangeEnd = (allowA, matchRange: Pattern.matchRange) => {
+  regex: RegExpFactory.compile(allowA, matchRange.endRegex),
   name: matchRange.name,
   captures: matchRange.endCaptures,
   popStack: Some(matchRange),
   pushStack: None,
 };
 
-let rec ofPatterns = (~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
+let rec ofPatterns = (~isFirstLine, ~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
   let f = (prev, pattern) => {
     switch (pattern) {
     | Pattern.Include(inc) =>
       switch (getScope(inc)) {
       | None => prev
-      | Some(v) => List.concat([ofPatterns(~getScope, ~scopeStack, v), prev])
+      | Some(v) => List.concat([ofPatterns(~isFirstLine, ~getScope, ~scopeStack, v), prev])
       }
     | Pattern.Match(match) =>
-      switch (ofMatch(match)) {
+      switch (ofMatch(isFirstLine, match)) {
       | None => prev
       | Some(v) => [v, ...prev]
       }
     | Pattern.MatchRange(matchRange) =>
-      switch (ofMatchRangeBegin(matchRange)) {
+      switch (ofMatchRangeBegin(isFirstLine, matchRange)) {
       | None => prev
       | Some(v) => [v, ...prev]
       }
@@ -73,7 +73,7 @@ let rec ofPatterns = (~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
 
   let initialRules =
     switch (activeRange) {
-    | Some(v) when v.applyEndPatternLast == true => [ofMatchRangeEnd(v)]
+    | Some(v) when v.applyEndPatternLast == true => [ofMatchRangeEnd(isFirstLine, v)]
     | _ => []
     };
 
@@ -81,7 +81,7 @@ let rec ofPatterns = (~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
 
   switch (activeRange) {
   | Some(v) when v.applyEndPatternLast == false => [
-      ofMatchRangeEnd(v),
+      ofMatchRangeEnd(isFirstLine, v),
       ...rules,
     ]
   | _ => rules

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -48,13 +48,18 @@ let ofMatchRangeEnd = (allowA, matchRange: Pattern.matchRange) => {
   pushStack: None,
 };
 
-let rec ofPatterns = (~isFirstLine, ~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
+let rec ofPatterns =
+        (~isFirstLine, ~getScope, ~scopeStack, patterns: list(Pattern.t)) => {
   let f = (prev, pattern) => {
     switch (pattern) {
     | Pattern.Include(inc) =>
       switch (getScope(inc)) {
       | None => prev
-      | Some(v) => List.concat([ofPatterns(~isFirstLine, ~getScope, ~scopeStack, v), prev])
+      | Some(v) =>
+        List.concat([
+          ofPatterns(~isFirstLine, ~getScope, ~scopeStack, v),
+          prev,
+        ])
       }
     | Pattern.Match(match) =>
       switch (ofMatch(isFirstLine, match)) {
@@ -73,7 +78,9 @@ let rec ofPatterns = (~isFirstLine, ~getScope, ~scopeStack, patterns: list(Patte
 
   let initialRules =
     switch (activeRange) {
-    | Some(v) when v.applyEndPatternLast == true => [ofMatchRangeEnd(isFirstLine, v)]
+    | Some(v) when v.applyEndPatternLast == true => [
+        ofMatchRangeEnd(isFirstLine, v),
+      ]
     | _ => []
     };
 

--- a/src/Rule.re
+++ b/src/Rule.re
@@ -22,7 +22,7 @@ let show = (v: t) => {
 
 let ofMatch = (match: Pattern.match_) => {
   Some({
-    regex: RegExpFactory.getRegEx(match.matchRegex),
+    regex: RegExpFactory.compile(match.matchRegex),
     name: match.matchName,
     captures: match.captures,
     popStack: None,
@@ -32,7 +32,7 @@ let ofMatch = (match: Pattern.match_) => {
 
 let ofMatchRangeBegin = (matchRange: Pattern.matchRange) => {
   Some({
-    regex: RegExpFactory.getRegEx(matchRange.beginRegex),
+    regex: RegExpFactory.compile(matchRange.beginRegex),
     name: matchRange.name,
     captures: matchRange.beginCaptures,
     popStack: None,
@@ -41,7 +41,7 @@ let ofMatchRangeBegin = (matchRange: Pattern.matchRange) => {
 };
 
 let ofMatchRangeEnd = (matchRange: Pattern.matchRange) => {
-  regex: RegExpFactory.getRegEx(matchRange.endRegex),
+  regex: RegExpFactory.compile(matchRange.endRegex),
   name: matchRange.name,
   captures: matchRange.endCaptures,
   popStack: Some(matchRange),

--- a/src/ScopeStack.re
+++ b/src/ScopeStack.re
@@ -108,7 +108,7 @@ let pushPattern =
   ignore(line);
 
   let newMatchRange =
-    if (RegExp.hasBackReferences(matchRange.endRegex)) {
+    if (RegExpFactory.hasBackReferences(matchRange.endRegex)) {
       // If the end range has back references, we need to resolve them from the provided matches
 
       let matchGroups =
@@ -120,7 +120,7 @@ let pushPattern =
            });
 
       let resolvedEndRegex =
-        RegExp.supplyReferences(matchGroups, matchRange.endRegex);
+        RegExpFactory.supplyReferences(matchGroups, matchRange.endRegex);
       {...matchRange, endRegex: resolvedEndRegex};
     } else {
       matchRange;

--- a/src/TextMate.re
+++ b/src/TextMate.re
@@ -1,4 +1,5 @@
 module Grammar = Grammar;
+module RegExpFactory = RegExpFactory;
 module RegExp = RegExp;
 module ScopeStack = ScopeStack;
 module Theme = Theme;

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -241,5 +241,5 @@ describe("FirstMate", ({test, _}) => {
   let _ = firstMateTestSuite;
   let _ = onivimTestSuite;
   FirstMateTestSuite.run(runTest, firstMateTestSuite);
-  FirstMateTestSuite.run(runTest, onivimTestSuite);
+//  FirstMateTestSuite.run(runTest, onivimTestSuite);
 });

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -240,6 +240,6 @@ describe("FirstMate", ({test, _}) => {
   let _ = runTest;
   let _ = firstMateTestSuite;
   let _ = onivimTestSuite;
-  //FirstMateTestSuite.run(runTest, firstMateTestSuite);
+  FirstMateTestSuite.run(runTest, firstMateTestSuite);
    FirstMateTestSuite.run(runTest, onivimTestSuite);
 });

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -240,6 +240,6 @@ describe("FirstMate", ({test, _}) => {
   let _ = runTest;
   let _ = firstMateTestSuite;
   let _ = onivimTestSuite;
-  FirstMateTestSuite.run(runTest, firstMateTestSuite);
- //  FirstMateTestSuite.run(runTest, onivimTestSuite);
+  //FirstMateTestSuite.run(runTest, firstMateTestSuite);
+   FirstMateTestSuite.run(runTest, onivimTestSuite);
 });

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -119,7 +119,12 @@ module FirstMateTest = {
       );
       let scopes = scopeStack^;
       let (tokens, newScopeStack) =
-        Grammar.tokenize(~lineNumber=idx^, ~scopes=Some(scopes), ~grammar, l.line);
+        Grammar.tokenize(
+          ~lineNumber=idx^,
+          ~scopes=Some(scopes),
+          ~grammar,
+          l.line,
+        );
       List.iter(t => prerr_endline(Token.show(t)), tokens);
 
       let expectedTokens = l.tokens;
@@ -241,5 +246,5 @@ describe("FirstMate", ({test, _}) => {
   let _ = firstMateTestSuite;
   let _ = onivimTestSuite;
   FirstMateTestSuite.run(runTest, firstMateTestSuite);
-   FirstMateTestSuite.run(runTest, onivimTestSuite);
+  FirstMateTestSuite.run(runTest, onivimTestSuite);
 });

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -241,5 +241,5 @@ describe("FirstMate", ({test, _}) => {
   let _ = firstMateTestSuite;
   let _ = onivimTestSuite;
   FirstMateTestSuite.run(runTest, firstMateTestSuite);
-//  FirstMateTestSuite.run(runTest, onivimTestSuite);
+  //  FirstMateTestSuite.run(runTest, onivimTestSuite);
 });

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -119,7 +119,7 @@ module FirstMateTest = {
       );
       let scopes = scopeStack^;
       let (tokens, newScopeStack) =
-        Grammar.tokenize(~scopes=Some(scopes), ~grammar, l.line);
+        Grammar.tokenize(~lineNumber=idx^, ~scopes=Some(scopes), ~grammar, l.line);
       List.iter(t => prerr_endline(Token.show(t)), tokens);
 
       let expectedTokens = l.tokens;
@@ -241,5 +241,5 @@ describe("FirstMate", ({test, _}) => {
   let _ = firstMateTestSuite;
   let _ = onivimTestSuite;
   FirstMateTestSuite.run(runTest, firstMateTestSuite);
-  //  FirstMateTestSuite.run(runTest, onivimTestSuite);
+ //  FirstMateTestSuite.run(runTest, onivimTestSuite);
 });

--- a/test/GrammarCaptureTests.re
+++ b/test/GrammarCaptureTests.re
@@ -7,14 +7,11 @@ open TestFramework;
 
 module Grammar = Textmate.Grammar;
 module RegExp = Textmate.RegExp;
+module RegExpFactory = Textmate.RegExpFactory;
 module Token = Textmate.Token;
 
 let createRegex = str => {
-  switch (RegExp.create(str)) {
-  | Ok(v) => v
-  | Error(msg) =>
-    failwith("Unable to parse regex: " ++ str ++ " message: " ++ msg)
-  };
+  RegExpFactory.create(str);
 };
 
 describe("GrammarCaptureTests", ({test, _}) => {

--- a/test/GrammarTests.re
+++ b/test/GrammarTests.re
@@ -1,15 +1,12 @@
 open TestFramework;
 
 module Grammar = Textmate.Grammar;
+module RegExpFactory = Textmate.RegExpFactory;
 module RegExp = Textmate.RegExp;
 module Token = Textmate.Token;
 
 let createRegex = str => {
-  switch (RegExp.create(str)) {
-  | Ok(v) => v
-  | Error(msg) =>
-    failwith("Unable to parse regex: " ++ str ++ " message: " ++ msg)
-  };
+  RegExpFactory.create(str);
 };
 
 let getExecutingDirectory = () => {

--- a/test/RegExpFactoryTests.re
+++ b/test/RegExpFactoryTests.re
@@ -3,7 +3,7 @@ open TestFramework;
 module RegExpFactory = Textmate.RegExpFactory;
 
 let createRegex = str => {
-  RegExpFactory.create(str)
+  RegExpFactory.create(str);
 };
 
 describe("RegExpFactory", ({describe, _}) => {

--- a/test/RegExpFactoryTests.re
+++ b/test/RegExpFactoryTests.re
@@ -1,24 +1,20 @@
 open TestFramework;
 
-module RegExp = Textmate.RegExp;
+module RegExpFactory = Textmate.RegExpFactory;
 
 let createRegex = str => {
-  switch (RegExp.create(str)) {
-  | Ok(v) => v
-  | Error(msg) =>
-    failwith("Unable to parse regex: " ++ str ++ " message: " ++ msg)
-  };
+  RegExpFactory.create(str)
 };
 
-describe("RegExp", ({describe, _}) => {
+describe("RegExpFactory", ({describe, _}) => {
   describe("hasBackReferences", ({test, _}) => {
     test("returns false if no backreferences", ({expect, _}) => {
       let re = createRegex("a|b|c");
-      expect.bool(RegExp.hasBackReferences(re)).toBe(false);
+      expect.bool(RegExpFactory.hasBackReferences(re)).toBe(false);
     });
     test("returns true if has backreferences", ({expect, _}) => {
       let re = createRegex("^(?!\\1(?=\\S))");
-      expect.bool(RegExp.hasBackReferences(re)).toBe(true);
+      expect.bool(RegExpFactory.hasBackReferences(re)).toBe(true);
     });
   });
 
@@ -26,15 +22,15 @@ describe("RegExp", ({describe, _}) => {
     test("back references get replaced", ({expect, _}) => {
       let re = createRegex("\\1");
 
-      let newRe = RegExp.supplyReferences([(1, "abc")], re);
-      expect.bool(RegExp.hasBackReferences(newRe)).toBe(false);
-      expect.string(RegExp.toString(newRe)).toEqual("abc");
+      let newRe = RegExpFactory.supplyReferences([(1, "abc")], re);
+      expect.bool(RegExpFactory.hasBackReferences(newRe)).toBe(false);
+      expect.string(RegExpFactory.show(newRe)).toEqual("abc");
     })
   });
 
   describe("escapeRegExpCharacters", ({test, _}) => {
     test("escape characters get replaced", ({expect, _}) => {
-      let t = RegExp.escapeRegExpCharacters;
+      let t = RegExpFactory.escapeRegExpCharacters;
 
       let validate = (str, expected) => {
         let _ = expect.string(t(str)).toEqual(expected);

--- a/test/RegExpFactoryTests.re
+++ b/test/RegExpFactoryTests.re
@@ -1,12 +1,34 @@
 open TestFramework;
 
 module RegExpFactory = Textmate.RegExpFactory;
+module RegExp = Textmate.RegExp;
 
 let createRegex = str => {
   RegExpFactory.create(str);
 };
 
 describe("RegExpFactory", ({describe, _}) => {
+  describe("hasAnchors", ({test, _}) => {
+    test("returns false if no anchors", ({expect, _}) => {
+      let re = createRegex("a|b|c");
+      expect.bool(RegExpFactory.hasAnchors(re)).toBe(false);
+    });
+    test("returns true if has \\A anchor", ({expect, _}) => {
+      let re = createRegex("\\A^(?!\\1(?=\\S))");
+      expect.bool(RegExpFactory.hasAnchors(re)).toBe(true);
+    });
+  });
+
+  describe("compile", ({test, _}) => {
+    test("allowA", ({expect, _}) => {
+      let re = createRegex("\\A");
+      let re_a0 = RegExpFactory.compile(false, re) |> RegExp.raw;
+      let re_a1 = RegExpFactory.compile(true, re) |> RegExp.raw;
+      expect.string(re_a0).toEqual("\\uFFFF");
+      expect.string(re_a1).toEqual("\\A");
+    });
+  });
+  
   describe("hasBackReferences", ({test, _}) => {
     test("returns false if no backreferences", ({expect, _}) => {
       let re = createRegex("a|b|c");

--- a/test/RegExpFactoryTests.re
+++ b/test/RegExpFactoryTests.re
@@ -26,9 +26,9 @@ describe("RegExpFactory", ({describe, _}) => {
       let re_a1 = RegExpFactory.compile(true, re) |> RegExp.raw;
       expect.string(re_a0).toEqual("\\uFFFF");
       expect.string(re_a1).toEqual("\\A");
-    });
+    })
   });
-  
+
   describe("hasBackReferences", ({test, _}) => {
     test("returns false if no backreferences", ({expect, _}) => {
       let re = createRegex("a|b|c");

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -1404,59 +1404,5 @@
 			"fixtures/loops.json"
 		],
 		"desc": "TEST #74"
-	},
-	{
-		"grammarPath": "fixtures/git-commit.json",
-		"lines": [
-			{
-				"line": "longggggggggggggggggggggggggggggggggggggggggggggggg",
-				"tokens": [
-					{
-						"value": "longggggggggggggggggggggggggggggggggggggggggggggggg",
-						"scopes": [
-							"text.git-commit",
-							"meta.scope.message.git-commit",
-							"invalid.deprecated.line-too-long.git-commit"
-						]
-					}
-				]
-			},
-			{
-				"line": "# Please enter the commit message for your changes. Lines starting",
-				"tokens": [
-					{
-						"value": "#",
-						"scopes": [
-							"text.git-commit",
-							"meta.scope.metadata.git-commit",
-							"comment.line.number-sign.git-commit",
-							"punctuation.definition.comment.git-commit"
-						]
-					},
-					{
-						"value": " Please enter the commit message for your changes. Lines starting",
-						"scopes": [
-							"text.git-commit",
-							"meta.scope.metadata.git-commit",
-							"comment.line.number-sign.git-commit"
-						]
-					}
-				]
-			}
-		],
-		"grammars": [
-			"fixtures/text.json",
-			"fixtures/javascript.json",
-			"fixtures/javascript-regex.json",
-			"fixtures/coffee-script.json",
-			"fixtures/ruby.json",
-			"fixtures/html-erb.json",
-			"fixtures/html.json",
-			"fixtures/php.json",
-			"fixtures/python.json",
-			"fixtures/python-regex.json",
-			"fixtures/git-commit.json"
-		],
-		"desc": "TEST #54"
 	}
 ]

--- a/test/first-mate/tests.json
+++ b/test/first-mate/tests.json
@@ -1404,5 +1404,59 @@
 			"fixtures/loops.json"
 		],
 		"desc": "TEST #74"
+	},
+	{
+		"grammarPath": "fixtures/git-commit.json",
+		"lines": [
+			{
+				"line": "longggggggggggggggggggggggggggggggggggggggggggggggg",
+				"tokens": [
+					{
+						"value": "longggggggggggggggggggggggggggggggggggggggggggggggg",
+						"scopes": [
+							"text.git-commit",
+							"meta.scope.message.git-commit",
+							"invalid.deprecated.line-too-long.git-commit"
+						]
+					}
+				]
+			},
+			{
+				"line": "# Please enter the commit message for your changes. Lines starting",
+				"tokens": [
+					{
+						"value": "#",
+						"scopes": [
+							"text.git-commit",
+							"meta.scope.metadata.git-commit",
+							"comment.line.number-sign.git-commit",
+							"punctuation.definition.comment.git-commit"
+						]
+					},
+					{
+						"value": " Please enter the commit message for your changes. Lines starting",
+						"scopes": [
+							"text.git-commit",
+							"meta.scope.metadata.git-commit",
+							"comment.line.number-sign.git-commit"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/text.json",
+			"fixtures/javascript.json",
+			"fixtures/javascript-regex.json",
+			"fixtures/coffee-script.json",
+			"fixtures/ruby.json",
+			"fixtures/html-erb.json",
+			"fixtures/html.json",
+			"fixtures/php.json",
+			"fixtures/python.json",
+			"fixtures/python-regex.json",
+			"fixtures/git-commit.json"
+		],
+		"desc": "TEST #54"
 	}
 ]

--- a/test/onivim/fixtures/anchor-a.json
+++ b/test/onivim/fixtures/anchor-a.json
@@ -1,0 +1,19 @@
+{
+	"name": "anchor-a",
+	"scopeName": "source.anchor-a",
+	"fileTypes": [
+		"world"
+	],
+	"patterns": [
+		{
+			"comment": "Handle A anchor correctly",
+			"match": "\\Ahello",
+			"name": "hello.first-line"
+		},
+		{
+			"comment": "Handle A anchor correctly",
+			"match": "hello",
+			"name": "hello.after-first-line"
+		}
+	]
+}

--- a/test/onivim/tests.json
+++ b/test/onivim/tests.json
@@ -190,5 +190,38 @@
 			"fixtures/reason.json"
 		],
 		"desc": "ONIVIM TEST #3 - ReasonML module"
+	},
+	{
+		"grammarPath": "fixtures/anchor-a.json",
+		"lines": [
+			{
+				"line": "hello",
+				"tokens": [
+					{
+						"value": "hello",
+						"scopes": [
+							"source.anchor-a",
+							"hello.first-line"
+						]
+					}
+				]
+			},
+			{
+				"line": "hello",
+				"tokens": [
+					{
+						"value": "hello",
+						"scopes": [
+							"source.anchor-a",
+							"hello.after-first-line"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/anchor-a.json"
+		],
+		"desc": "ONIVIM TEST #4 - anchor A"
 	}
 ]


### PR DESCRIPTION
This handles the `\\A` anchor - which only matches on the first line, and not on other lines.