### PR TITLE
Bugfix: Fix issue with Reason JSX rendering

### DIFF
--- a/src/Grammar.re
+++ b/src/Grammar.re
@@ -232,7 +232,6 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
     // And figure out if any of the rules applies.
     let bestRule = _getBestRule(lastMatchedRange^, rules, line, i);
 
-
     switch (bestRule) {
     // No matching rule... just increment position and try again
     | None => incr(idx)
@@ -244,9 +243,9 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
 
       // Logging around rule evaluation
       /*
-      print_endline ("Last anchor position: " ++ string_of_int(lastAnchorPosition^));
-      print_endline ("Matching rule: " ++ Rule.show(rule));
-      */
+       print_endline ("Last anchor position: " ++ string_of_int(lastAnchorPosition^));
+       print_endline ("Matching rule: " ++ Rule.show(rule));
+       */
 
       if (ltp < matches[0].startPos) {
         let newToken =
@@ -257,7 +256,7 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
             (),
           );
         lastTokenPosition := matches[0].startPos;
-        
+
         // Logging around token creation
         /*
          print_endline ("Match - startPos: "
@@ -265,7 +264,7 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
              ++ "endPos: " ++ string_of_int(matches[0].endPos));
            print_endline("Creating token at " ++ string_of_int(ltp) ++ ":" ++ Token.show(newToken));
          */
-         
+
         let prevToken = [newToken];
         tokens := [prevToken, ...tokens^];
       };
@@ -330,15 +329,14 @@ let tokenize = (~lineNumber=0, ~scopes=None, ~grammar: t, line: string) => {
       let prevIndex = idx^;
       idx := max(matches[0].endPos, prevIndex);
 
-
       let pos = idx^;
       switch (rule.popStack, rule.pushStack) {
       // If the rule isn't a push or pop rule, and we're at the same index, we're stuck
       // in a loop - we'll push forward a character in that case.
       | (None, None) when pos <= prevIndex => incr(idx)
       // Otherwise, if it's a push rule, record that we pushed so that we can break an infinite loop
-      | (None, Some(mr)) => 
-        lastMatchedRange := Some((prevIndex, mr))
+      | (None, Some(mr)) =>
+        lastMatchedRange := Some((prevIndex, mr));
         lastAnchorPosition := matches[0].endPos;
       | _ => ()
       };

--- a/test/FirstMateTests.re
+++ b/test/FirstMateTests.re
@@ -259,6 +259,6 @@ describe("FirstMate", ({test, _}) => {
   let _ = runTest;
   let _ = firstMateTestSuite;
   let _ = onivimTestSuite;
-  FirstMateTestSuite.run(runTest, onivimTestSuite);
   FirstMateTestSuite.run(runTest, firstMateTestSuite);
+  FirstMateTestSuite.run(runTest, onivimTestSuite);
 });

--- a/test/onivim/tests.json
+++ b/test/onivim/tests.json
@@ -223,5 +223,57 @@
 			"fixtures/anchor-a.json"
 		],
 		"desc": "ONIVIM TEST #4 - anchor A"
+	},
+	{
+		"grammarPath": "fixtures/reason.json",
+		"lines": [
+			{
+				"line": "<Test abc/>",
+				"tokens": [
+					{
+						"value": "<",
+						"scopes": [
+							"source.reason",
+							"punctuation.definition.tag.begin.js"
+						]
+					},
+					{
+						"value": "Test",
+						"scopes": [
+							"source.reason",
+							"support.class",
+							"entity.name.class"
+						]
+					},
+					{
+						"value": " ",
+						"scopes": [
+							"source.reason"
+						]
+					},
+					{
+						"value": "abc",
+						"scopes": [
+							"source.reason",
+							"markup.inserted",
+							"constant.language",
+							"support.property-value",
+							"entity.name.filename"
+						]
+					},
+					{
+						"value": "/>",
+						"scopes": [
+							"source.reason",
+							"punctuation.definition.tag.end.js"
+						]
+					}
+				]
+			}
+		],
+		"grammars": [
+			"fixtures/reason.json"
+		],
+		"desc": "ONIVIM TEST #5 - ReasonML JSX"
 	}
 ]


### PR DESCRIPTION
There was a bug with the recently implemented `\\G` handled that impacted reason - when there'd be a JSX block, it would cause every token after to be rendered in red.

This fixes our `\\G` handling to only record the last anchor position in the case of begin / end rules, and adds a test specific to validate this case w/ our Reason grammar.