### PR TITLE
Bugfix: Correct default token colors

### DIFF
--- a/src/Theme.re
+++ b/src/Theme.re
@@ -22,10 +22,10 @@ let of_yojson = (~isDark=?, ~themeLoader, json: Yojson.Safe.t) => {
       switch (isDark) {
       | Some(v) => v
       | None =>
-      switch (Yojson.Safe.Util.member("type", json)) {
-      | `String("dark") => true
-      | _ => false
-      };
+        switch (Yojson.Safe.Util.member("type", json)) {
+        | `String("dark") => true
+        | _ => false
+        }
       };
 
     let defaultBackground = isDark ? "#1E1E1E" : "#FFFFFF";
@@ -109,7 +109,8 @@ let rec from_file = (~isDark=?, path: string) => {
       let fullPath = Path.join(currentDirectory, p);
       from_file(fullPath);
     };
-    let ret = Yojson.Safe.from_file(path) |> of_yojson(~isDark?, ~themeLoader);
+    let ret =
+      Yojson.Safe.from_file(path) |> of_yojson(~isDark?, ~themeLoader);
     Hashtbl.add(_themeCache, path, ret);
     ret;
   };

--- a/src/Theme.re
+++ b/src/Theme.re
@@ -12,22 +12,35 @@ type t = {
 
 type themeLoader = string => t;
 
-let of_yojson = (~themeLoader, json: Yojson.Safe.t) => {
+let of_yojson = (~isDark=?, ~themeLoader, json: Yojson.Safe.t) => {
   let parse = json => {
     let colorsJson = Yojson.Safe.Util.member("colors", json);
 
     let colorTheme = ColorTheme.of_yojson(colorsJson);
 
+    let isDark =
+      switch (isDark) {
+      | Some(v) => v
+      | None =>
+      switch (Yojson.Safe.Util.member("type", json)) {
+      | `String("dark") => true
+      | _ => false
+      };
+      };
+
+    let defaultBackground = isDark ? "#1E1E1E" : "#FFFFFF";
+    let defaultForeground = isDark ? "#D4D4D4" : "#000000";
+
     let defaultBackground =
       ColorTheme.getFirstOrDefault(
-        ~default="#000",
+        ~default=defaultBackground,
         ["background", "editor.background"],
         colorTheme,
       );
 
     let defaultForeground =
       ColorTheme.getFirstOrDefault(
-        ~default="#FFF",
+        ~default=defaultForeground,
         ["foreground", "editor.foreground"],
         colorTheme,
       );
@@ -40,12 +53,6 @@ let of_yojson = (~themeLoader, json: Yojson.Safe.t) => {
         ~defaultForeground,
         tokenColorsJson,
       );
-
-    let isDark =
-      switch (Yojson.Safe.Util.member("type", json)) {
-      | `String("dark") => true
-      | _ => false
-      };
 
     // Is there an included theme? If so - we need to parse that
     let incl = Yojson.Safe.Util.member("include", json);
@@ -93,7 +100,7 @@ let of_yojson = (~themeLoader, json: Yojson.Safe.t) => {
 
 let _themeCache: Hashtbl.t(string, t) = Hashtbl.create(16);
 
-let rec from_file = (path: string) => {
+let rec from_file = (~isDark=?, path: string) => {
   switch (Hashtbl.find_opt(_themeCache, path)) {
   | Some(v) => v
   | None =>
@@ -102,7 +109,7 @@ let rec from_file = (path: string) => {
       let fullPath = Path.join(currentDirectory, p);
       from_file(fullPath);
     };
-    let ret = Yojson.Safe.from_file(path) |> of_yojson(~themeLoader);
+    let ret = Yojson.Safe.from_file(path) |> of_yojson(~isDark?, ~themeLoader);
     Hashtbl.add(_themeCache, path, ret);
     ret;
   };

--- a/src/Theme.rei
+++ b/src/Theme.rei
@@ -8,7 +8,8 @@ type t;
 
 type themeLoader = string => t;
 
-let of_yojson: (~isDark: bool=?, ~themeLoader: themeLoader, Yojson.Safe.t) => t;
+let of_yojson:
+  (~isDark: bool=?, ~themeLoader: themeLoader, Yojson.Safe.t) => t;
 let from_file: (~isDark: bool=?, string) => t;
 
 let getColors: t => ColorTheme.t;

--- a/src/Theme.rei
+++ b/src/Theme.rei
@@ -8,8 +8,8 @@ type t;
 
 type themeLoader = string => t;
 
-let of_yojson: (~themeLoader: themeLoader, Yojson.Safe.t) => t;
-let from_file: string => t;
+let of_yojson: (~isDark: bool=?, ~themeLoader: themeLoader, Yojson.Safe.t) => t;
+let from_file: (~isDark: bool=?, string) => t;
 
 let getColors: t => ColorTheme.t;
 let getTokenColors: t => TokenTheme.t;


### PR DESCRIPTION
The default token colors weren't always correct, in the case where a `type` is not specified in the `theme`, but _is_ specified via the `uiTheme` in the plugin configuration.

This adds a hook to override the `isDark` flag - since the theme doesn't know about this, just the extension configuration, and use correct defaults.